### PR TITLE
feat: OpenAI Tools Bridge — translate OpenAI function-calling to MCP

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod jwt;
 pub mod live_config;
 pub mod metrics;
 pub mod middleware;
+pub mod openai_bridge;
 pub mod prompt_injection;
 pub mod schema_cache;
 pub mod transport;

--- a/src/openai_bridge.rs
+++ b/src/openai_bridge.rs
@@ -1,0 +1,236 @@
+/// Format conversion between OpenAI function-calling and MCP tool formats.
+///
+/// OpenAI tool (in `tools` array):
+/// ```json
+/// { "type": "function", "function": { "name": "...", "description": "...", "parameters": {...} } }
+/// ```
+///
+/// MCP tool (in `tools/list` result):
+/// ```json
+/// { "name": "...", "description": "...", "inputSchema": {...} }
+/// ```
+///
+/// OpenAI tool call (from LLM assistant message):
+/// ```json
+/// { "id": "call_abc", "type": "function", "function": { "name": "...", "arguments": "{...}" } }
+/// ```
+///
+/// MCP `tools/call` request:
+/// ```json
+/// { "jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": { "name": "...", "arguments": {...} } }
+/// ```
+use serde_json::{Value, json};
+
+/// Convert a MCP `tools/list` response into an OpenAI `tools` array.
+///
+/// Each MCP tool becomes:
+/// `{ "type": "function", "function": { "name", "description", "parameters" } }`
+pub fn mcp_tools_to_openai(mcp_response: &Value) -> Vec<Value> {
+    let Some(tools) = mcp_response["result"]["tools"].as_array() else {
+        return vec![];
+    };
+
+    tools
+        .iter()
+        .map(|tool| {
+            let name = tool["name"].as_str().unwrap_or("").to_string();
+            let description = tool["description"].as_str().unwrap_or("").to_string();
+            // MCP uses `inputSchema`; OpenAI uses `parameters` — same JSON Schema shape.
+            let parameters = tool
+                .get("inputSchema")
+                .cloned()
+                .unwrap_or_else(|| json!({"type": "object", "properties": {}}));
+
+            json!({
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "description": description,
+                    "parameters": parameters
+                }
+            })
+        })
+        .collect()
+}
+
+/// Convert an OpenAI tool call object into a MCP `tools/call` JSON-RPC request.
+///
+/// `arguments` in OpenAI is a JSON-encoded string; MCP expects a parsed object.
+/// Returns `None` if the tool call is malformed.
+pub fn openai_tool_call_to_mcp(tool_call: &Value, request_id: u64) -> Option<Value> {
+    let name = tool_call["function"]["name"].as_str()?;
+    let args_raw = tool_call["function"]["arguments"].as_str().unwrap_or("{}");
+    let arguments: Value = serde_json::from_str(args_raw).unwrap_or(json!({}));
+
+    Some(json!({
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": "tools/call",
+        "params": {
+            "name": name,
+            "arguments": arguments
+        }
+    }))
+}
+
+/// Convert a MCP `tools/call` response into an OpenAI tool result message.
+///
+/// Returns an OpenAI `messages` entry with `role: "tool"`.
+pub fn mcp_result_to_openai(mcp_response: &Value, tool_call_id: &str) -> Value {
+    let content = if let Some(arr) = mcp_response["result"]["content"].as_array() {
+        arr.iter()
+            .filter_map(|c| c["text"].as_str())
+            .collect::<Vec<_>>()
+            .join("\n")
+    } else if let Some(err) = mcp_response["error"]["message"].as_str() {
+        format!("error: {err}")
+    } else {
+        String::new()
+    };
+
+    json!({
+        "role": "tool",
+        "tool_call_id": tool_call_id,
+        "content": content
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ── mcp_tools_to_openai ───────────────────────────────────────────────────
+
+    #[test]
+    fn converts_mcp_tool_to_openai_format() {
+        let mcp = json!({
+            "result": {
+                "tools": [{
+                    "name": "read_file",
+                    "description": "Read a file from disk",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": { "path": { "type": "string" } },
+                        "required": ["path"]
+                    }
+                }]
+            }
+        });
+
+        let tools = mcp_tools_to_openai(&mcp);
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0]["type"], "function");
+        assert_eq!(tools[0]["function"]["name"], "read_file");
+        assert_eq!(tools[0]["function"]["description"], "Read a file from disk");
+        assert_eq!(
+            tools[0]["function"]["parameters"]["properties"]["path"]["type"],
+            "string"
+        );
+    }
+
+    #[test]
+    fn missing_input_schema_defaults_to_empty_object() {
+        let mcp = json!({
+            "result": {
+                "tools": [{ "name": "ping", "description": "Ping" }]
+            }
+        });
+
+        let tools = mcp_tools_to_openai(&mcp);
+        assert_eq!(
+            tools[0]["function"]["parameters"],
+            json!({"type": "object", "properties": {}})
+        );
+    }
+
+    #[test]
+    fn empty_tools_list_returns_empty_vec() {
+        let mcp = json!({ "result": { "tools": [] } });
+        assert!(mcp_tools_to_openai(&mcp).is_empty());
+    }
+
+    #[test]
+    fn malformed_response_returns_empty_vec() {
+        assert!(mcp_tools_to_openai(&json!({})).is_empty());
+    }
+
+    // ── openai_tool_call_to_mcp ───────────────────────────────────────────────
+
+    #[test]
+    fn converts_openai_tool_call_to_mcp_request() {
+        let tool_call = json!({
+            "id": "call_abc123",
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "arguments": "{\"path\": \"/tmp/test.txt\"}"
+            }
+        });
+
+        let mcp = openai_tool_call_to_mcp(&tool_call, 42).unwrap();
+        assert_eq!(mcp["method"], "tools/call");
+        assert_eq!(mcp["id"], 42);
+        assert_eq!(mcp["params"]["name"], "read_file");
+        assert_eq!(mcp["params"]["arguments"]["path"], "/tmp/test.txt");
+    }
+
+    #[test]
+    fn invalid_json_arguments_defaults_to_empty_object() {
+        let tool_call = json!({
+            "id": "call_1",
+            "type": "function",
+            "function": { "name": "ping", "arguments": "not-json" }
+        });
+
+        let mcp = openai_tool_call_to_mcp(&tool_call, 1).unwrap();
+        assert_eq!(mcp["params"]["arguments"], json!({}));
+    }
+
+    #[test]
+    fn missing_function_name_returns_none() {
+        let tool_call = json!({ "id": "call_1", "type": "function", "function": {} });
+        assert!(openai_tool_call_to_mcp(&tool_call, 1).is_none());
+    }
+
+    // ── mcp_result_to_openai ──────────────────────────────────────────────────
+
+    #[test]
+    fn converts_mcp_result_to_openai_tool_message() {
+        let mcp = json!({
+            "result": {
+                "content": [{ "type": "text", "text": "file contents here" }]
+            }
+        });
+
+        let msg = mcp_result_to_openai(&mcp, "call_abc");
+        assert_eq!(msg["role"], "tool");
+        assert_eq!(msg["tool_call_id"], "call_abc");
+        assert_eq!(msg["content"], "file contents here");
+    }
+
+    #[test]
+    fn mcp_error_becomes_error_string_in_content() {
+        let mcp = json!({
+            "error": { "code": -32603, "message": "file not found" }
+        });
+
+        let msg = mcp_result_to_openai(&mcp, "call_1");
+        assert_eq!(msg["content"], "error: file not found");
+    }
+
+    #[test]
+    fn multiple_content_items_are_joined() {
+        let mcp = json!({
+            "result": {
+                "content": [
+                    { "type": "text", "text": "line one" },
+                    { "type": "text", "text": "line two" }
+                ]
+            }
+        });
+
+        let msg = mcp_result_to_openai(&mcp, "call_1");
+        assert_eq!(msg["content"], "line one\nline two");
+    }
+}

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -6,6 +6,7 @@ use crate::{
     jwt::MultiJwtValidator,
     live_config::LiveConfig,
     metrics::GatewayMetrics,
+    openai_bridge::{mcp_result_to_openai, mcp_tools_to_openai, openai_tool_call_to_mcp},
 };
 use async_trait::async_trait;
 use axum::response::sse::{Event, KeepAlive, Sse};
@@ -168,6 +169,8 @@ impl Transport for HttpTransport {
             .route("/approvals", get(handle_list_approvals))
             .route("/approvals/{id}/approve", post(handle_approve))
             .route("/approvals/{id}/reject", post(handle_reject))
+            .route("/openai/v1/tools", get(handle_openai_tools))
+            .route("/openai/v1/execute", post(handle_openai_execute))
             .with_state(state);
 
         if let Some(tls) = &self.tls {
@@ -783,9 +786,102 @@ fn parse_and_filter_sse(raw: &str, config_rx: &watch::Receiver<Arc<LiveConfig>>)
     Some(Event::default().event(event_type).data(data))
 }
 
-/// Resolve agent_id from Mcp-Session-Id (MCP spec).
-/// Falls back to x-agent-id header for clients that skip session management.
-/// Returns 404 if Mcp-Session-Id is present but unknown or expired.
+// ── OpenAI bridge ─────────────────────────────────────────────────────────────
+
+/// `GET /openai/v1/tools` — returns the agent's available tools in OpenAI function format.
+///
+/// Headers:
+///   `X-Agent-Id: <agent>` or `Mcp-Session-Id: <sid>`
+async fn handle_openai_tools(
+    State(state): State<Arc<HttpState>>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    let agent_id = match resolve_agent(&state.sessions, &headers).await {
+        Ok(id) => id,
+        Err(status) => return (status, Json(serde_json::Value::Null)).into_response(),
+    };
+    let client_ip = Some(peer.ip().to_string());
+
+    let list_req = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}
+    });
+    let (response, _, _) = state.gateway.handle(&agent_id, list_req, client_ip).await;
+
+    let tools = response
+        .as_ref()
+        .map(mcp_tools_to_openai)
+        .unwrap_or_default();
+
+    Json(serde_json::json!({ "tools": tools })).into_response()
+}
+
+/// `POST /openai/v1/execute` — execute one or more OpenAI tool calls via the MCP gateway.
+///
+/// Request body:
+/// ```json
+/// { "tool_calls": [ { "id": "call_abc", "type": "function",
+///                     "function": { "name": "...", "arguments": "{...}" } } ] }
+/// ```
+///
+/// Response body:
+/// ```json
+/// { "tool_results": [ { "role": "tool", "tool_call_id": "...", "content": "..." } ] }
+/// ```
+async fn handle_openai_execute(
+    State(state): State<Arc<HttpState>>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    let agent_id = match resolve_agent(&state.sessions, &headers).await {
+        Ok(id) => id,
+        Err(status) => return (status, Json(serde_json::Value::Null)).into_response(),
+    };
+    let client_ip = Some(peer.ip().to_string());
+
+    let Some(tool_calls) = body["tool_calls"].as_array() else {
+        return (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(serde_json::json!({"error": "missing `tool_calls` array"})),
+        )
+            .into_response();
+    };
+
+    let mut results = Vec::new();
+    for (i, tool_call) in tool_calls.iter().enumerate() {
+        let tool_call_id = tool_call["id"].as_str().unwrap_or("").to_string();
+
+        let Some(mcp_req) = openai_tool_call_to_mcp(tool_call, i as u64 + 1) else {
+            results.push(serde_json::json!({
+                "role": "tool",
+                "tool_call_id": tool_call_id,
+                "content": "error: malformed tool call"
+            }));
+            continue;
+        };
+
+        let (response, _, _) = state
+            .gateway
+            .handle(&agent_id, mcp_req, client_ip.clone())
+            .await;
+
+        let result = response
+            .as_ref()
+            .map(|r| mcp_result_to_openai(r, &tool_call_id))
+            .unwrap_or_else(|| {
+                serde_json::json!({
+                    "role": "tool",
+                    "tool_call_id": tool_call_id,
+                    "content": ""
+                })
+            });
+        results.push(result);
+    }
+
+    Json(serde_json::json!({ "tool_results": results })).into_response()
+}
+
 async fn resolve_agent(sessions: &SessionStore, headers: &HeaderMap) -> Result<String, StatusCode> {
     if let Some(sid) = headers.get("mcp-session-id").and_then(|v| v.to_str().ok()) {
         return sessions.resolve(sid).await.ok_or(StatusCode::NOT_FOUND);


### PR DESCRIPTION
Closes #6

## Summary

- `GET /openai/v1/tools` — returns available tools in OpenAI function format
- `POST /openai/v1/execute` — accepts OpenAI `tool_calls`, executes via MCP, returns `tool_results`
- All requests pass through the full gateway middleware pipeline (auth, rate limiting, payload filtering, schema validation)

## Format mapping

| OpenAI | MCP |
|---|---|
| `tools[].function.parameters` | `inputSchema` |
| `tool_calls[].function.arguments` (JSON string) | `params.arguments` (parsed object) |
| `messages[role=tool].content` | `result.content[].text` |

## Usage

```bash
# List tools in OpenAI format
curl http://localhost:4000/openai/v1/tools -H "X-Agent-Id: my-agent"

# Execute tool calls
curl -X POST http://localhost:4000/openai/v1/execute \
  -H "X-Agent-Id: my-agent" \
  -H "Content-Type: application/json" \
  -d '{
    "tool_calls": [{
      "id": "call_abc",
      "type": "function",
      "function": { "name": "read_file", "arguments": "{\"path\": \"/tmp/test.txt\"}" }
    }]
  }'
```

## Changes

| File | What changed |
|---|---|
| `src/openai_bridge.rs` | New module — pure conversion functions + 10 unit tests |
| `src/transport/http.rs` | Two new routes + handlers |
| `src/lib.rs` | Module registered |

## Test plan

- [x] `cargo fmt --check` — passes
- [x] `cargo clippy -- -D warnings` — passes
- [x] `cargo test --lib` — 308 tests pass (10 new in `openai_bridge`)
- [x] `mcp_tools_to_openai` — converts correctly, handles missing schema, empty list
- [x] `openai_tool_call_to_mcp` — parses JSON string args, handles invalid JSON, missing name
- [x] `mcp_result_to_openai` — maps content, surfaces errors, joins multiple content items

🤖 Generated with [Claude Code](https://claude.ai/claude-code)