### PR TITLE
feat: OpenLineage audit backend for data lineage tracking (#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.11.0] — 2026-03-31
+
+### Added
+- **OpenLineage Integration**: new `openlineage` audit backend emits OpenLineage `RunEvent` (spec 2-0-2) on every `tools/call`:
+  - `eventType` maps to `COMPLETE` (allowed/forwarded/shadowed) or `FAIL` (blocked)
+  - `job.namespace` / `job.name` encode `<namespace>/<agent_id>/<tool_name>` for lineage graph navigation
+  - `run.runId` is the existing `X-Request-Id` UUID — correlates lineage events with audit log entries
+  - `run.facets` includes `arbit:execution` (outcome, agent, input_tokens) and `arbit:arguments` (captured tool arguments)
+  - `inputs[]` dataset entry identifies the tool and agent as the lineage source
+  - Configurable `namespace`, optional Bearer token auth; non-tools/call events skipped automatically
+  - Enables LGPD/GDPR compliance tracing: "AI generated response X based on tool Y which queried Z"
+- **`AuditConfig::OpenLineage`** variant: `url`, `token` (optional), `namespace` (default: `"arbit"`) — fully backward compatible
+
+---
+
 ## [0.10.0] — 2026-03-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Agent (Cursor, Claude, etc.)
 - **Health check** — `GET /health` returns upstream status; `503` when any upstream is degraded
 - **Config hot-reload** — reload on `SIGUSR1` or automatically every 30 seconds without restart
 - **Cost Observability** — per-agent token estimation (4-chars-per-token heuristic); `arbit_tokens_total` Prometheus counter with `agent`/`direction` labels for chargeback dashboards; `input_tokens` stored in the SQLite audit log per request
+- **OpenLineage** — `openlineage` audit backend emits `RunEvent` (spec 2-0-2) per `tools/call`; `run.runId` correlates with `X-Request-Id`; enables LGPD/GDPR data lineage tracing ("agent X called tool Y which accessed Z")
 - **Metrics** — Prometheus-compatible `/metrics` endpoint
 - **Dashboard** — `/dashboard` audit viewer with per-agent filtering
 - **TLS** — optional HTTPS with certificate and key files
@@ -301,6 +302,7 @@ audits:
 | `type: stdout` | Print entries to stdout (default) |
 | `type: sqlite` | Persist to a SQLite database at `path` |
 | `type: webhook` | POST each entry as JSON to `url` |
+| `type: openlineage` | POST OpenLineage `RunEvent` to `url` |
 
 #### Webhook — plain JSON
 
@@ -358,6 +360,52 @@ CloudEvents envelope:
 ```
 
 Event types follow the reverse-DNS convention: `dev.arbit.audit.<outcome>` where outcome is `allowed`, `blocked`, `forwarded`, or `shadowed`.
+
+#### OpenLineage
+
+Emits an OpenLineage `RunEvent` (spec 2-0-2) for every `tools/call`. Enables data lineage tracing for LGPD/GDPR compliance: "agent X called tool Y which accessed Z".
+
+```yaml
+audit:
+  type: openlineage
+  url: "https://api.openlineage.io/api/v1/lineage"
+  token: "my-api-key"   # optional — sent as Bearer token
+  namespace: "arbit"    # optional — OpenLineage job.namespace, default: "arbit"
+```
+
+Or fan-out alongside other backends:
+
+```yaml
+audits:
+  - type: sqlite
+    path: "gateway-audit.db"
+  - type: openlineage
+    url: "https://marquez.internal/api/v1/lineage"
+    namespace: "prod-gateway"
+```
+
+Payload sent per `tools/call`:
+
+```json
+{
+  "eventType": "COMPLETE",
+  "eventTime": "2026-03-31T00:54:00Z",
+  "run": {
+    "runId": "550e8400-e29b-41d4-a716-446655440000",
+    "facets": {
+      "arbit:execution": { "outcome": "allowed", "agent": "cursor", "input_tokens": 12 },
+      "arbit:arguments": { "arguments": { "path": "/etc/hosts" } }
+    }
+  },
+  "job": { "namespace": "arbit", "name": "cursor/read_file", "facets": {} },
+  "inputs": [{ "namespace": "cursor", "name": "read_file" }],
+  "outputs": [],
+  "producer": "https://github.com/nfvelten/arbit",
+  "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/definitions/RunEvent"
+}
+```
+
+`eventType` is `COMPLETE` for allowed/forwarded/shadowed and `FAIL` for blocked. The `run.runId` matches the `X-Request-Id` header so lineage events can be correlated with audit log entries.
 
 ## Usage
 

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -1,4 +1,5 @@
 pub mod fanout;
+pub mod openlineage;
 pub mod sqlite;
 pub mod stdout;
 pub mod webhook;

--- a/src/audit/openlineage.rs
+++ b/src/audit/openlineage.rs
@@ -1,0 +1,289 @@
+/// OpenLineage audit backend.
+///
+/// Emits an OpenLineage `RunEvent` (spec 2-0-2) for every `tools/call` audit entry.
+/// Non-tool-call entries (method ≠ `tools/call`) are skipped — they carry no lineage data.
+///
+/// ## Event mapping
+///
+/// | OpenLineage field            | arbit source                                     |
+/// |------------------------------|--------------------------------------------------|
+/// | `run.runId`                  | `entry.request_id` (UUID)                        |
+/// | `job.namespace`              | configurable `namespace` (default: `"arbit"`)    |
+/// | `job.name`                   | `<agent_id>/<tool_name>`                         |
+/// | `eventType`                  | `COMPLETE` (allowed/forwarded) / `FAIL` (blocked)|
+/// | `eventTime`                  | `entry.ts` in RFC 3339 format                    |
+/// | `run.facets.arbit:execution` | outcome, reason, agent_id, input_tokens          |
+/// | `inputs[0]`                  | `{namespace: agent_id, name: tool_name}`         |
+/// | `producer`                   | `"https://github.com/nfvelten/arbit"`            |
+use super::{AuditEntry, AuditLog, Outcome};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use reqwest::Client;
+use serde_json::{Value, json};
+use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
+use tokio::sync::mpsc;
+
+const PRODUCER: &str = "https://github.com/nfvelten/arbit";
+const SCHEMA_URL: &str = "https://openlineage.io/spec/2-0-2/OpenLineage.json#/definitions/RunEvent";
+
+pub struct OpenLineageAudit {
+    tx: Arc<Mutex<Option<mpsc::UnboundedSender<Arc<AuditEntry>>>>>,
+    handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
+}
+
+impl OpenLineageAudit {
+    pub fn new(url: impl Into<String>, token: Option<String>, namespace: String) -> Self {
+        let url = url.into();
+        let client = Client::new();
+        let (tx, mut rx) = mpsc::unbounded_channel::<Arc<AuditEntry>>();
+
+        let handle = tokio::spawn(async move {
+            while let Some(entry) = rx.recv().await {
+                // Only tools/call carries actionable lineage data.
+                if entry.method != "tools/call" {
+                    continue;
+                }
+
+                let body = build_run_event(&entry, &namespace);
+
+                let mut req = client
+                    .post(&url)
+                    .header("Content-Type", "application/json")
+                    .json(&body);
+                if let Some(tok) = &token {
+                    req = req.header("Authorization", format!("Bearer {tok}"));
+                }
+
+                if let Err(e) = req.send().await {
+                    tracing::warn!(error = %e, "openlineage delivery failed");
+                }
+            }
+        });
+
+        Self {
+            tx: Arc::new(Mutex::new(Some(tx))),
+            handle: Arc::new(Mutex::new(Some(handle))),
+        }
+    }
+}
+
+#[async_trait]
+impl AuditLog for OpenLineageAudit {
+    fn record(&self, entry: Arc<AuditEntry>) {
+        if let Ok(guard) = self.tx.lock()
+            && let Some(tx) = guard.as_ref()
+        {
+            let _ = tx.send(entry);
+        }
+    }
+
+    async fn flush(&self) {
+        {
+            let mut guard = self.tx.lock().unwrap();
+            *guard = None;
+        }
+        let handle = {
+            let mut guard = self.handle.lock().unwrap();
+            guard.take()
+        };
+        if let Some(h) = handle {
+            let _ = h.await;
+        }
+    }
+}
+
+/// Build an OpenLineage `RunEvent` from an `AuditEntry`.
+///
+/// Exported for unit testing without requiring an HTTP server.
+pub fn build_run_event(entry: &AuditEntry, namespace: &str) -> Value {
+    let event_time = {
+        let dt: DateTime<Utc> = entry
+            .ts
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map(|d| {
+                DateTime::from_timestamp(d.as_secs() as i64, d.subsec_nanos()).unwrap_or_default()
+            })
+            .unwrap_or_default();
+        dt.to_rfc3339()
+    };
+
+    let tool_name = entry.tool.as_deref().unwrap_or("unknown");
+    let job_name = format!("{}/{}", entry.agent_id, tool_name);
+
+    let (event_type, outcome_str, reason) = match &entry.outcome {
+        Outcome::Allowed | Outcome::Forwarded | Outcome::Shadowed => {
+            ("COMPLETE", outcome_label(&entry.outcome), None::<&str>)
+        }
+        Outcome::Blocked(r) => ("FAIL", "blocked", Some(r.as_str())),
+    };
+
+    // Execution facet — carries arbit-specific metadata.
+    let mut facet_data = json!({
+        "_producer": PRODUCER,
+        "_schemaURL": format!("{PRODUCER}/facets/execution"),
+        "outcome": outcome_str,
+        "agent": entry.agent_id,
+        "input_tokens": entry.input_tokens,
+    });
+    if let Some(r) = reason {
+        facet_data["reason"] = json!(r);
+    }
+
+    // Arguments facet — only present when arguments were captured.
+    let run_facets = if let Some(args) = &entry.arguments {
+        json!({
+            "arbit:execution": facet_data,
+            "arbit:arguments": {
+                "_producer": PRODUCER,
+                "_schemaURL": format!("{PRODUCER}/facets/arguments"),
+                "arguments": args
+            }
+        })
+    } else {
+        json!({ "arbit:execution": facet_data })
+    };
+
+    json!({
+        "eventType": event_type,
+        "eventTime": event_time,
+        "run": {
+            "runId": entry.request_id,
+            "facets": run_facets
+        },
+        "job": {
+            "namespace": namespace,
+            "name": job_name,
+            "facets": {}
+        },
+        "inputs": [{
+            "namespace": entry.agent_id,
+            "name": tool_name
+        }],
+        "outputs": [],
+        "producer": PRODUCER,
+        "schemaURL": SCHEMA_URL
+    })
+}
+
+fn outcome_label(outcome: &Outcome) -> &'static str {
+    match outcome {
+        Outcome::Allowed => "allowed",
+        Outcome::Forwarded => "forwarded",
+        Outcome::Shadowed => "shadowed",
+        Outcome::Blocked(_) => "blocked",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audit::Outcome;
+    use std::time::{Duration, UNIX_EPOCH};
+
+    fn entry(outcome: Outcome) -> Arc<AuditEntry> {
+        Arc::new(AuditEntry {
+            ts: UNIX_EPOCH + Duration::from_secs(1_743_375_600),
+            agent_id: "cursor".to_string(),
+            method: "tools/call".to_string(),
+            tool: Some("read_file".to_string()),
+            arguments: Some(serde_json::json!({"path": "/etc/hosts"})),
+            outcome,
+            request_id: "550e8400-e29b-41d4-a716-446655440000".to_string(),
+            input_tokens: 8,
+        })
+    }
+
+    #[test]
+    fn allowed_produces_complete_event() {
+        let ev = build_run_event(&entry(Outcome::Allowed), "arbit");
+        assert_eq!(ev["eventType"], "COMPLETE");
+        assert_eq!(ev["schemaURL"], SCHEMA_URL);
+        assert_eq!(ev["producer"], PRODUCER);
+    }
+
+    #[test]
+    fn blocked_produces_fail_event() {
+        let ev = build_run_event(&entry(Outcome::Blocked("rate limit".into())), "arbit");
+        assert_eq!(ev["eventType"], "FAIL");
+        assert_eq!(ev["run"]["facets"]["arbit:execution"]["outcome"], "blocked");
+        assert_eq!(
+            ev["run"]["facets"]["arbit:execution"]["reason"],
+            "rate limit"
+        );
+    }
+
+    #[test]
+    fn job_name_combines_agent_and_tool() {
+        let ev = build_run_event(&entry(Outcome::Allowed), "arbit");
+        assert_eq!(ev["job"]["name"], "cursor/read_file");
+        assert_eq!(ev["job"]["namespace"], "arbit");
+    }
+
+    #[test]
+    fn run_id_matches_request_id() {
+        let ev = build_run_event(&entry(Outcome::Allowed), "arbit");
+        assert_eq!(ev["run"]["runId"], "550e8400-e29b-41d4-a716-446655440000");
+    }
+
+    #[test]
+    fn input_dataset_uses_agent_and_tool() {
+        let ev = build_run_event(&entry(Outcome::Allowed), "arbit");
+        let inputs = ev["inputs"].as_array().unwrap();
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(inputs[0]["namespace"], "cursor");
+        assert_eq!(inputs[0]["name"], "read_file");
+    }
+
+    #[test]
+    fn arguments_facet_present_when_args_captured() {
+        let ev = build_run_event(&entry(Outcome::Allowed), "arbit");
+        assert_eq!(
+            ev["run"]["facets"]["arbit:arguments"]["arguments"]["path"],
+            "/etc/hosts"
+        );
+    }
+
+    #[test]
+    fn arguments_facet_absent_when_no_args() {
+        let e = Arc::new(AuditEntry {
+            ts: UNIX_EPOCH,
+            agent_id: "cursor".to_string(),
+            method: "tools/call".to_string(),
+            tool: Some("ping".to_string()),
+            arguments: None,
+            outcome: Outcome::Allowed,
+            request_id: "req-1".to_string(),
+            input_tokens: 0,
+        });
+        let ev = build_run_event(&e, "arbit");
+        assert!(
+            ev["run"]["facets"]["arbit:arguments"].is_null(),
+            "arguments facet should be absent"
+        );
+    }
+
+    #[test]
+    fn input_tokens_in_execution_facet() {
+        let ev = build_run_event(&entry(Outcome::Allowed), "arbit");
+        assert_eq!(ev["run"]["facets"]["arbit:execution"]["input_tokens"], 8);
+    }
+
+    #[test]
+    fn custom_namespace_used() {
+        let ev = build_run_event(&entry(Outcome::Allowed), "my-gateway");
+        assert_eq!(ev["job"]["namespace"], "my-gateway");
+    }
+
+    #[test]
+    fn event_time_is_rfc3339() {
+        let ev = build_run_event(&entry(Outcome::Allowed), "arbit");
+        let t = ev["eventTime"].as_str().unwrap();
+        // Should parse as a valid RFC 3339 timestamp
+        assert!(t.contains('T'), "eventTime should be ISO 8601: {t}");
+        assert!(
+            t.ends_with('Z') || t.contains('+'),
+            "should have timezone: {t}"
+        );
+    }
+}

--- a/src/bin/arbit.rs
+++ b/src/bin/arbit.rs
@@ -1,7 +1,7 @@
 use arbit::{
     audit::{
-        AuditLog, fanout::FanoutAudit, sqlite::SqliteAudit, stdout::StdoutAudit,
-        webhook::WebhookAudit,
+        AuditLog, fanout::FanoutAudit, openlineage::OpenLineageAudit, sqlite::SqliteAudit,
+        stdout::StdoutAudit, webhook::WebhookAudit,
     },
     config::{AuditConfig, Config, TelemetryConfig, TransportConfig},
     gateway::McpGateway,
@@ -773,6 +773,18 @@ fn build_audit_backend(cfg: &AuditConfig) -> anyhow::Result<Arc<dyn AuditLog>> {
                 token.clone(),
                 *cloudevents,
                 source.clone(),
+            )))
+        }
+        AuditConfig::OpenLineage {
+            url,
+            token,
+            namespace,
+        } => {
+            tracing::info!(url, namespace, "openlineage audit");
+            Ok(Arc::new(OpenLineageAudit::new(
+                url,
+                token.clone(),
+                namespace.clone(),
             )))
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -171,10 +171,24 @@ pub enum AuditConfig {
         #[serde(default = "default_ce_source")]
         source: String,
     },
+    OpenLineage {
+        /// OpenLineage API endpoint (e.g. `https://api.openlineage.io/api/v1/lineage`).
+        url: String,
+        /// Optional Bearer token sent in the Authorization header.
+        token: Option<String>,
+        /// OpenLineage `job.namespace` — identifies this gateway instance.
+        /// Defaults to `"arbit"`.
+        #[serde(default = "default_ol_namespace")]
+        namespace: String,
+    },
 }
 
 fn default_ce_source() -> String {
     "/arbit".to_string()
+}
+
+fn default_ol_namespace() -> String {
+    "arbit".to_string()
 }
 
 fn default_db_path() -> String {


### PR DESCRIPTION
## Summary

- `audit/openlineage.rs`: async HTTP backend (mpsc worker, same pattern as WebhookAudit) that emits OpenLineage `RunEvent` spec 2-0-2 per `tools/call`
- `run.runId` = `X-Request-Id` UUID — correlates lineage events with SQLite audit entries
- `run.facets` includes `arbit:execution` (outcome, agent, input_tokens) and `arbit:arguments` (tool arguments)
- `eventType` maps to `COMPLETE` (allowed/forwarded/shadowed) or `FAIL` (blocked)
- Non-`tools/call` entries skipped automatically (no lineage value)
- `AuditConfig::OpenLineage { url, token, namespace }` — fully backward compatible, works standalone or in `audits:` fan-out
- README docs: config example, full payload sample, Marquez fan-out example
- CHANGELOG v0.11.0

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test --lib` passes (328 tests, +10 new)
- [x] `eventType` COMPLETE/FAIL mapping
- [x] `job.name` = `<namespace>/<agent>/<tool>`, `job.namespace` configurable
- [x] `run.runId` matches `request_id`
- [x] `inputs[0]` dataset encoding
- [x] `arbit:arguments` facet present/absent based on captured args
- [x] `input_tokens` in `arbit:execution` facet
- [x] RFC 3339 `eventTime` format

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)