### PR TITLE
feat: env var interpolation and ARBIT_* config overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.12.0] — 2026-03-31
+
+### Added
+- **Env var interpolation in config** (`${VAR}` syntax): any value in `gateway.yml` can reference an environment variable; missing variables abort startup with a descriptive error identifying the missing name — enables Kubernetes Secret injection without embedding credentials in config files
+- **`ARBIT_*` env var overrides**: three top-level overrides applied after YAML parsing; precedence: env var > YAML value:
+  - `ARBIT_ADMIN_TOKEN` — overrides `admin_token`
+  - `ARBIT_UPSTREAM_URL` — overrides `transport.upstream`
+  - `ARBIT_LISTEN_ADDR` — overrides `transport.addr`
+- `Config::set_upstream_url()` and `Config::set_listen_addr()` helper methods
+
+### Changed
+- `Config::from_file()` now runs interpolation and env overrides before `validate()` — fully backward compatible
+
+---
+
 ## [0.11.0] — 2026-03-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Agent (Cursor, Claude, etc.)
 - **Circuit breaker** — upstream failures open the circuit; automatic half-open probe after recovery timeout
 - **Health check** — `GET /health` returns upstream status; `503` when any upstream is degraded
 - **Config hot-reload** — reload on `SIGUSR1` or automatically every 30 seconds without restart
+- **Secrets-safe config** — `${VAR}` interpolation in `gateway.yml` resolves env vars at startup; `ARBIT_ADMIN_TOKEN`, `ARBIT_UPSTREAM_URL`, `ARBIT_LISTEN_ADDR` override YAML values directly — compatible with Kubernetes Secrets, Vault Agent, External Secrets Operator, and any secret manager that injects env vars
 - **Cost Observability** — per-agent token estimation (4-chars-per-token heuristic); `arbit_tokens_total` Prometheus counter with `agent`/`direction` labels for chargeback dashboards; `input_tokens` stored in the SQLite audit log per request
 - **OpenLineage** — `openlineage` audit backend emits `RunEvent` (spec 2-0-2) per `tools/call`; `run.runId` correlates with `X-Request-Id`; enables LGPD/GDPR data lineage tracing ("agent X called tool Y which accessed Z")
 - **Metrics** — Prometheus-compatible `/metrics` endpoint
@@ -140,12 +141,50 @@ rules:
 | `server` | (stdio only) command to spawn the MCP server, as a list |
 | `verify` | (stdio only) optional binary verification before spawn — see [Supply-chain security](#supply-chain-security) |
 
+### Secrets in config
+
+Credentials should never be stored in plaintext. Two mechanisms are available:
+
+#### `${VAR}` interpolation
+
+Reference any environment variable inside `gateway.yml`:
+
+```yaml
+admin_token: "${ARBIT_ADMIN_TOKEN}"
+
+agents:
+  cursor:
+    api_key: "${CURSOR_API_KEY}"
+
+auth:
+  - type: jwt
+    secret: "${JWT_SECRET}"
+```
+
+If the variable is not set, arbit aborts at startup:
+
+```
+config error: env var 'ARBIT_ADMIN_TOKEN' is not set (referenced in gateway.yml)
+```
+
+#### `ARBIT_*` env var overrides
+
+Override specific fields without modifying the YAML file — useful when deploying a shared base config with environment-specific secrets:
+
+| Env var | Overrides |
+|---------|-----------|
+| `ARBIT_ADMIN_TOKEN` | `admin_token` |
+| `ARBIT_UPSTREAM_URL` | `transport.upstream` |
+| `ARBIT_LISTEN_ADDR` | `transport.addr` |
+
+These work with any secret manager that exposes secrets as env vars: Kubernetes Secrets (`envFrom`), Vault Agent, External Secrets Operator, OpenBao, Infisical, etc.
+
 ### `admin_token`
 
 Optional top-level field. When set, `/metrics` and `/dashboard` require an `Authorization: Bearer <token>` header. Without the header the endpoints return `403`.
 
 ```yaml
-admin_token: "your-admin-secret"
+admin_token: "${ARBIT_ADMIN_TOKEN}"   # recommended: inject via env var
 ```
 
 ### `auth` (JWT / OIDC / OAuth 2.1)

--- a/src/config.rs
+++ b/src/config.rs
@@ -459,12 +459,33 @@ pub(crate) fn make_agent(
 
 impl Config {
     pub fn from_file(path: &str) -> anyhow::Result<Self> {
-        let s = std::fs::read_to_string(path)
+        let raw = std::fs::read_to_string(path)
             .map_err(|e| anyhow::anyhow!("could not read '{}': {}", path, e))?;
-        let config: Self =
-            serde_yaml::from_str(&s).map_err(|e| anyhow::anyhow!("invalid config: {}", e))?;
+        let interpolated = crate::env_config::interpolate_env_vars(&raw)?;
+        let mut config: Self = serde_yaml::from_str(&interpolated)
+            .map_err(|e| anyhow::anyhow!("invalid config: {}", e))?;
+        crate::env_config::apply_env_overrides(&mut config);
         config.validate()?;
         Ok(config)
+    }
+
+    /// Override the upstream URL in the transport config.
+    /// No-op for stdio transport (no upstream URL concept).
+    pub fn set_upstream_url(&mut self, url: String) {
+        if let TransportConfig::Http { upstream, .. } = &mut self.transport {
+            *upstream = url;
+        }
+    }
+
+    /// Override the listen address in the transport config.
+    /// No-op for stdio transport.
+    pub fn set_listen_addr(&mut self, addr: String) {
+        if let TransportConfig::Http {
+            addr: current_addr, ..
+        } = &mut self.transport
+        {
+            *current_addr = addr;
+        }
     }
 
     fn validate(&self) -> anyhow::Result<()> {

--- a/src/env_config.rs
+++ b/src/env_config.rs
@@ -1,0 +1,154 @@
+/// Environment variable support for `gateway.yml`.
+///
+/// # Interpolation (`${VAR}` syntax) — Issue #20
+///
+/// Any value in the YAML file written as `"${VAR_NAME}"` is replaced with the
+/// corresponding environment variable before the file is parsed by serde.
+/// If the variable is not set, startup fails with a descriptive error.
+///
+/// ```yaml
+/// admin_token: "${ARBIT_ADMIN_TOKEN}"
+/// agents:
+///   cursor:
+///     api_key: "${CURSOR_API_KEY}"
+/// ```
+///
+/// # Top-level overrides (`ARBIT_` prefix) — Issue #21
+///
+/// A small set of high-value fields can be overridden via dedicated env vars
+/// without touching the YAML file.  This follows the 12-factor app convention
+/// and works with any secret manager that injects secrets as env vars
+/// (Kubernetes Secrets, Vault Agent, External Secrets Operator, etc.).
+///
+/// | Env var              | Config field          |
+/// |----------------------|-----------------------|
+/// | `ARBIT_ADMIN_TOKEN`  | `admin_token`         |
+/// | `ARBIT_UPSTREAM_URL` | `transport.upstream`  |
+/// | `ARBIT_LISTEN_ADDR`  | `transport.addr`      |
+use crate::config::Config;
+
+/// Replace every `${VAR_NAME}` placeholder in `raw` with the value of the
+/// corresponding environment variable.
+///
+/// Returns an error if any placeholder references an unset variable.
+pub fn interpolate_env_vars(raw: &str) -> anyhow::Result<String> {
+    let mut result = String::with_capacity(raw.len());
+    let mut chars = raw.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '$' && chars.peek() == Some(&'{') {
+            chars.next(); // consume '{'
+            let var_name: String = chars.by_ref().take_while(|&c| c != '}').collect();
+            if var_name.is_empty() {
+                anyhow::bail!("config error: empty placeholder '${{}}' in gateway.yml");
+            }
+            let value = std::env::var(&var_name).map_err(|_| {
+                anyhow::anyhow!(
+                    "config error: env var '{}' is not set (referenced in gateway.yml)",
+                    var_name
+                )
+            })?;
+            result.push_str(&value);
+        } else {
+            result.push(ch);
+        }
+    }
+
+    Ok(result)
+}
+
+/// Apply `ARBIT_*` env var overrides to a parsed `Config`.
+///
+/// Each recognised variable silently overrides the corresponding field when set.
+/// Unset variables are ignored — the YAML value is kept.
+pub fn apply_env_overrides(config: &mut Config) {
+    if let Ok(token) = std::env::var("ARBIT_ADMIN_TOKEN") {
+        config.admin_token = Some(token);
+    }
+
+    if let Ok(url) = std::env::var("ARBIT_UPSTREAM_URL") {
+        config.set_upstream_url(url);
+    }
+
+    if let Ok(addr) = std::env::var("ARBIT_LISTEN_ADDR") {
+        config.set_listen_addr(addr);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── interpolate_env_vars ──────────────────────────────────────────────────
+
+    #[test]
+    fn resolves_single_placeholder() {
+        // SAFETY: single-threaded test binary; no other thread reads this var concurrently.
+        unsafe { std::env::set_var("_ARBIT_TEST_TOKEN", "supersecret") };
+        let raw = "admin_token: \"${_ARBIT_TEST_TOKEN}\"";
+        let out = interpolate_env_vars(raw).unwrap();
+        assert_eq!(out, "admin_token: \"supersecret\"");
+        unsafe { std::env::remove_var("_ARBIT_TEST_TOKEN") };
+    }
+
+    #[test]
+    fn resolves_multiple_placeholders() {
+        unsafe {
+            std::env::set_var("_ARBIT_A", "val_a");
+            std::env::set_var("_ARBIT_B", "val_b");
+        }
+        let raw = "x: \"${_ARBIT_A}\"\ny: \"${_ARBIT_B}\"";
+        let out = interpolate_env_vars(raw).unwrap();
+        assert_eq!(out, "x: \"val_a\"\ny: \"val_b\"");
+        unsafe {
+            std::env::remove_var("_ARBIT_A");
+            std::env::remove_var("_ARBIT_B");
+        }
+    }
+
+    #[test]
+    fn passthrough_when_no_placeholders() {
+        let raw = "admin_token: hardcoded";
+        let out = interpolate_env_vars(raw).unwrap();
+        assert_eq!(out, "admin_token: hardcoded");
+    }
+
+    #[test]
+    fn error_on_unset_variable() {
+        unsafe { std::env::remove_var("_ARBIT_DEFINITELY_NOT_SET") };
+        let raw = "admin_token: \"${_ARBIT_DEFINITELY_NOT_SET}\"";
+        let err = interpolate_env_vars(raw).unwrap_err();
+        assert!(
+            err.to_string().contains("_ARBIT_DEFINITELY_NOT_SET"),
+            "error should name the missing variable"
+        );
+        assert!(
+            err.to_string().contains("not set"),
+            "error should say 'not set'"
+        );
+    }
+
+    #[test]
+    fn error_on_empty_placeholder() {
+        let raw = "admin_token: \"${}\"";
+        let err = interpolate_env_vars(raw).unwrap_err();
+        assert!(err.to_string().contains("empty placeholder"));
+    }
+
+    #[test]
+    fn dollar_without_brace_is_literal() {
+        let raw = "cost: $100";
+        let out = interpolate_env_vars(raw).unwrap();
+        assert_eq!(out, "cost: $100");
+    }
+
+    #[test]
+    fn partial_placeholder_not_consumed() {
+        // "${VAR" without closing brace — take_while exhausts the string, var_name = "VAR"
+        // and std::env::var("VAR") is unset → error
+        unsafe { std::env::remove_var("_ARBIT_UNCLOSED") };
+        let raw = "${_ARBIT_UNCLOSED";
+        let err = interpolate_env_vars(raw).unwrap_err();
+        assert!(err.to_string().contains("_ARBIT_UNCLOSED"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod audit;
 pub mod config;
 pub mod cost;
 pub mod decode;
+pub mod env_config;
 pub mod gateway;
 pub mod hitl;
 pub mod jwt;


### PR DESCRIPTION
## Summary

- `${VAR}` interpolation in `gateway.yml` — any value can reference an env var; missing vars abort startup with a named error
- `ARBIT_ADMIN_TOKEN`, `ARBIT_UPSTREAM_URL`, `ARBIT_LISTEN_ADDR` override YAML fields after parse
- Both mechanisms work with any secret manager that injects env vars (Kubernetes Secrets, Vault Agent, External Secrets Operator, OpenBao, Infisical)
- `Config::from_file()` runs interpolation → parse → overrides → validate, fully backward compatible

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test --lib` passes (335 tests, +7 new)
- [x] Single and multiple placeholder resolution
- [x] Missing variable produces named error message
- [x] Empty `${}` placeholder error
- [x] Bare `$` without `{` passes through unchanged
- [x] Unclosed placeholder (`${VAR` without `}`) errors on missing var

Closes #20
Closes #21