### PR TITLE
feat: graceful SIGTERM shutdown for stdio transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.13.0] — 2026-03-31
+
+### Changed
+- **Graceful shutdown for stdio transport**: the main read loop now uses `tokio::select!` to race `stdin.next_line()` against SIGTERM/CTRL-C; on signal the loop breaks cleanly, the child process is drained, and the audit log is flushed before exit — previously SIGTERM killed the process immediately without flushing
+- **Shutdown log sequence**: `shutdown_signal()` (HTTP) now logs "draining active connections"; `arbit.rs` logs "flushing audit backends" and "shutdown complete" after transport exits — the audit flush is no longer misleadingly attributed to the signal handler
+
+---
+
 ## [0.12.0] — 2026-03-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Agent (Cursor, Claude, etc.)
 - **Circuit breaker** — upstream failures open the circuit; automatic half-open probe after recovery timeout
 - **Health check** — `GET /health` returns upstream status; `503` when any upstream is degraded
 - **Config hot-reload** — reload on `SIGUSR1` or automatically every 30 seconds without restart
+- **Graceful shutdown** — SIGTERM and CTRL-C handled in both HTTP and stdio transports; active connections are drained, child process closed, and all audit backends flushed before exit — safe for Kubernetes `terminationGracePeriodSeconds`
 - **Secrets-safe config** — `${VAR}` interpolation in `gateway.yml` resolves env vars at startup; `ARBIT_ADMIN_TOKEN`, `ARBIT_UPSTREAM_URL`, `ARBIT_LISTEN_ADDR` override YAML values directly — compatible with Kubernetes Secrets, Vault Agent, External Secrets Operator, and any secret manager that injects env vars
 - **Cost Observability** — per-agent token estimation (4-chars-per-token heuristic); `arbit_tokens_total` Prometheus counter with `agent`/`direction` labels for chargeback dashboards; `input_tokens` stored in the SQLite audit log per request
 - **OpenLineage** — `openlineage` audit backend emits `RunEvent` (spec 2-0-2) per `tools/call`; `run.runId` correlates with `X-Request-Id`; enables LGPD/GDPR data lineage tracing ("agent X called tool Y which accessed Z")

--- a/src/bin/arbit.rs
+++ b/src/bin/arbit.rs
@@ -363,7 +363,9 @@ async fn cmd_start(config_path: String) -> anyhow::Result<()> {
         }
     }
 
+    tracing::info!("flushing audit backends");
     audit.flush().await;
+    tracing::info!("shutdown complete");
     Ok(())
 }
 

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -229,7 +229,7 @@ async fn shutdown_signal() {
     {
         tokio::signal::ctrl_c().await.ok();
     }
-    tracing::info!("shutdown signal received, draining audit");
+    tracing::info!("shutdown signal received, draining active connections");
 }
 
 // ── Rate-limit header helper ──────────────────────────────────────────────────

--- a/src/transport/stdio.rs
+++ b/src/transport/stdio.rs
@@ -9,6 +9,25 @@ use tokio::{
     sync::Mutex,
 };
 
+/// Wait for SIGTERM (Unix) or CTRL-C (all platforms).
+/// Used by the stdio transport to break its read loop cleanly.
+async fn shutdown_signal_stdio() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+        let mut sigterm =
+            signal(SignalKind::terminate()).expect("failed to install SIGTERM handler");
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {},
+            _ = sigterm.recv() => {},
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        tokio::signal::ctrl_c().await.ok();
+    }
+}
+
 pub struct StdioTransport {
     server_cmd: Vec<String>,
     verify: Option<BinaryVerifyConfig>,
@@ -68,10 +87,26 @@ impl Transport for StdioTransport {
             }
         });
 
-        // Task B (main loop): our stdin → gateway intercept → child stdin or our stdout
+        // Task B (main loop): our stdin → gateway intercept → child stdin or our stdout.
+        // Exits cleanly on EOF *or* on SIGTERM/CTRL-C so the audit log is flushed before exit.
         let mut lines = BufReader::new(tokio::io::stdin()).lines();
+        let mut shutdown = std::pin::pin!(shutdown_signal_stdio());
 
-        while let Ok(Some(line)) = lines.next_line().await {
+        loop {
+            let line = tokio::select! {
+                result = lines.next_line() => {
+                    match result {
+                        Ok(Some(l)) => l,
+                        // EOF or read error — upstream process closed stdin
+                        _ => break,
+                    }
+                }
+                _ = &mut shutdown => {
+                    tracing::info!("shutdown signal received (stdio), draining child process");
+                    break;
+                }
+            };
+
             let line = line.trim().to_string();
             if line.is_empty() {
                 continue;


### PR DESCRIPTION
## Summary

The stdio transport had no SIGTERM handler — the process was killed immediately on signal without flushing audit backends. HTTP was already correct.

- `shutdown_signal_stdio()` in `stdio.rs` catches SIGTERM (Unix) and CTRL-C (all platforms)
- Main read loop uses `tokio::select!` to race `stdin.next_line()` against the shutdown signal — on signal: loop breaks → child stdin closed → passthrough task drained → `child.wait()` → `audit.flush()` in `arbit.rs`
- Fixed misleading log message in HTTP's `shutdown_signal()`: "draining audit" → "draining active connections"
- Added "flushing audit backends" and "shutdown complete" logs at the real flush point

## Shutdown sequence (both transports)

```
SIGTERM received
  → HTTP: stop accepting new connections, drain active requests (axum graceful_shutdown)
  → stdio: break read loop, close child stdin, drain passthrough, child.wait()
  ↓
transport.serve() returns
  ↓
"flushing audit backends" (arbit.rs)
  ↓
audit.flush() — SQLite worker drained, webhook queue emptied, OpenLineage queue emptied
  ↓
"shutdown complete"
  ↓
exit(0)
```

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test --lib` passes (335 tests)

Closes #17