### PR TITLE
feat: Helm chart for Kubernetes deployment with sidecar pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.15.0] — 2026-03-31
+
+### Added
+- **Helm chart** (`charts/arbit/`): production-ready chart for Kubernetes deployment
+  - `Deployment` with non-root security context, liveness/readiness probes, config checksum annotation (auto-restart on config change)
+  - `ConfigMap` renders `gateway.yml` from `values.yaml`; supports `${VAR}` placeholders resolved from env vars
+  - `Service` (ClusterIP), `ServiceAccount` (automount disabled)
+  - Optional `HorizontalPodAutoscaler` (CPU/memory), `PodDisruptionBudget`, `NetworkPolicy` (restrict ingress to `arbit-client: "true"` pods), `PersistentVolumeClaim` for SQLite audit log
+  - Sidecar pattern: `extraContainers` in `values.yaml` adds agent containers to the same Pod (shared network — agent reaches arbit at `localhost:4000`)
+  - `existingSecret` mounts a Kubernetes Secret as env vars via `envFrom`
+  - `terminationGracePeriodSeconds: 30` aligned with SIGTERM graceful shutdown
+
+---
+
 ## [0.14.0] — 2026-03-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Agent (Cursor, Claude, etc.)
 - **Circuit breaker** — upstream failures open the circuit; automatic half-open probe after recovery timeout
 - **Health check** — `GET /health` returns upstream status; `503` when any upstream is degraded
 - **Config hot-reload** — reload on `SIGUSR1` or automatically every 30 seconds without restart
+- **Helm chart** — production-ready chart at `charts/arbit/`; sidecar pattern via `extraContainers`; optional HPA, PDB, NetworkPolicy, PVC; `gateway.yml` rendered from `values.yaml`; secrets injected via `existingSecret` or `env`
 - **Container-ready** — multi-arch Docker image (`linux/amd64` + `linux/arm64`) published to `ghcr.io/nfvelten/arbit` on every release; runs as non-root (uid 10001); `LOG_FORMAT=json` structured logs; `docker-compose.yml` with healthcheck included
 - **Graceful shutdown** — SIGTERM and CTRL-C handled in both HTTP and stdio transports; active connections drained, child process closed, all audit backends flushed before exit — safe for Kubernetes `terminationGracePeriodSeconds`
 - **Secrets-safe config** — `${VAR}` interpolation in `gateway.yml` resolves env vars at startup; `ARBIT_ADMIN_TOKEN`, `ARBIT_UPSTREAM_URL`, `ARBIT_LISTEN_ADDR` override YAML values directly — compatible with Kubernetes Secrets, Vault Agent, External Secrets Operator, and any secret manager that injects env vars
@@ -447,6 +448,69 @@ Payload sent per `tools/call`:
 ```
 
 `eventType` is `COMPLETE` for allowed/forwarded/shadowed and `FAIL` for blocked. The `run.runId` matches the `X-Request-Id` header so lineage events can be correlated with audit log entries.
+
+## Helm
+
+```sh
+# Install with defaults (points upstream to $ARBIT_UPSTREAM_URL)
+helm install arbit ./charts/arbit \
+  --set env[0].name=ARBIT_UPSTREAM_URL \
+  --set env[0].value=http://mcp-server:3000/mcp
+
+# Install with an existing Kubernetes Secret
+helm install arbit ./charts/arbit --set existingSecret=arbit-secrets
+
+# Upgrade
+helm upgrade arbit ./charts/arbit -f my-values.yaml
+```
+
+```yaml
+# my-values.yaml — sidecar example
+config:
+  gateway: |
+    transport:
+      type: http
+      addr: "0.0.0.0:4000"
+      upstream: "${ARBIT_UPSTREAM_URL}"
+    agents:
+      my-agent:
+        allowed_tools: [read_file, list_dir]
+        rate_limit: 60
+    rules:
+      block_prompt_injection: true
+
+existingSecret: arbit-secrets   # must contain ARBIT_UPSTREAM_URL
+
+extraContainers:
+  - name: my-agent
+    image: my-org/my-agent:latest
+    env:
+      - name: MCP_GATEWAY_URL
+        value: http://localhost:4000/mcp
+```
+
+```
+┌─────────────────────────────────┐
+│  Pod                            │
+│  ┌──────────┐  ┌─────────────┐ │
+│  │  agent   │→ │    arbit    │ │
+│  │(sidecar) │  │  :4000/mcp  │ │
+│  └──────────┘  └──────┬──────┘ │
+└─────────────────────────│───────┘
+                          ↓
+                   MCP Server
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `image.tag` | `""` (appVersion) | Override image tag |
+| `existingSecret` | `""` | K8s Secret loaded via `envFrom` |
+| `env` | `[]` | Extra env vars injected into arbit |
+| `autoscaling.enabled` | `false` | Enable HPA |
+| `podDisruptionBudget.enabled` | `false` | Enable PDB |
+| `networkPolicy.enabled` | `false` | Restrict ingress to `arbit-client: "true"` pods |
+| `persistence.enabled` | `false` | PVC for SQLite audit log |
+| `extraContainers` | `[]` | Sidecar containers sharing Pod network |
 
 ## Docker
 

--- a/charts/arbit/.helmignore
+++ b/charts/arbit/.helmignore
@@ -1,0 +1,2 @@
+.DS_Store
+*.tgz

--- a/charts/arbit/Chart.yaml
+++ b/charts/arbit/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: arbit
+description: Security proxy for MCP servers — auth, rate limiting, payload filtering, and audit logging between AI agents and MCP servers.
+type: application
+version: 0.1.0
+appVersion: "0.14.0"
+home: https://github.com/nfvelten/arbit
+sources:
+  - https://github.com/nfvelten/arbit
+keywords:
+  - mcp
+  - ai
+  - security
+  - proxy
+  - gateway
+  - audit
+maintainers:
+  - name: nfvelten
+    url: https://github.com/nfvelten

--- a/charts/arbit/templates/NOTES.txt
+++ b/charts/arbit/templates/NOTES.txt
@@ -1,0 +1,18 @@
+arbit {{ .Chart.AppVersion }} has been deployed.
+
+Gateway endpoint (within the cluster):
+  http://{{ include "arbit.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/mcp
+
+Health check:
+  kubectl port-forward svc/{{ include "arbit.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }} -n {{ .Release.Namespace }}
+  curl http://localhost:{{ .Values.service.port }}/health
+
+Metrics (Prometheus):
+  curl http://localhost:{{ .Values.service.port }}/metrics
+
+View logs:
+  kubectl logs -l app.kubernetes.io/name={{ include "arbit.name" . }} -n {{ .Release.Namespace }} -f
+
+Sidecar pattern — add arbit to your agent pod by copying the arbit container spec
+from this Deployment into your own pod template. The agent reaches arbit at:
+  http://localhost:{{ .Values.service.port }}/mcp

--- a/charts/arbit/templates/_helpers.tpl
+++ b/charts/arbit/templates/_helpers.tpl
@@ -1,0 +1,68 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "arbit.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this.
+*/}}
+{{- define "arbit.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart label.
+*/}}
+{{- define "arbit.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "arbit.labels" -}}
+helm.sh/chart: {{ include "arbit.chart" . }}
+{{ include "arbit.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "arbit.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "arbit.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "arbit.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "arbit.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Image tag — defaults to chart appVersion.
+*/}}
+{{- define "arbit.imageTag" -}}
+{{- .Values.image.tag | default .Chart.AppVersion }}
+{{- end }}

--- a/charts/arbit/templates/configmap.yaml
+++ b/charts/arbit/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "arbit.fullname" . }}
+  labels:
+    {{- include "arbit.labels" . | nindent 4 }}
+data:
+  gateway.yml: |
+    {{- .Values.config.gateway | nindent 4 }}

--- a/charts/arbit/templates/deployment.yaml
+++ b/charts/arbit/templates/deployment.yaml
@@ -1,0 +1,110 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "arbit.fullname" . }}
+  labels:
+    {{- include "arbit.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "arbit.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        # Restart pods when the ConfigMap (gateway.yml) changes.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "arbit.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "arbit.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: arbit
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ include "arbit.imageTag" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - start
+            - /app/gateway.yml
+          ports:
+            - name: http
+              containerPort: 4000
+              protocol: TCP
+          env:
+            - name: LOG_FORMAT
+              value: json
+            - name: LOG_LEVEL
+              value: info
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.existingSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.existingSecret }}
+          {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /app/gateway.yml
+              subPath: gateway.yml
+              readOnly: true
+            {{- if .Values.persistence.enabled }}
+            - name: audit-data
+              mountPath: /app/data
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "arbit.fullname" . }}
+        {{- if .Values.persistence.enabled }}
+        - name: audit-data
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "arbit.fullname" .) }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/arbit/templates/hpa.yaml
+++ b/charts/arbit/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "arbit.fullname" . }}
+  labels:
+    {{- include "arbit.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "arbit.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/arbit/templates/networkpolicy.yaml
+++ b/charts/arbit/templates/networkpolicy.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "arbit.fullname" . }}
+  labels:
+    {{- include "arbit.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "arbit.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow traffic from pods labelled arbit-client: "true" (AI agents)
+    - from:
+        - podSelector:
+            matchLabels:
+              arbit-client: "true"
+      ports:
+        - protocol: TCP
+          port: 4000
+    # Allow Kubernetes liveness/readiness probes from the kubelet
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: TCP
+          port: 4000
+    {{- with .Values.networkPolicy.additionalIngressRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/arbit/templates/pdb.yaml
+++ b/charts/arbit/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "arbit.fullname" . }}
+  labels:
+    {{- include "arbit.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "arbit.selectorLabels" . | nindent 6 }}
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/charts/arbit/templates/pvc.yaml
+++ b/charts/arbit/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "arbit.fullname" . }}
+  labels:
+    {{- include "arbit.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/charts/arbit/templates/service.yaml
+++ b/charts/arbit/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "arbit.fullname" . }}
+  labels:
+    {{- include "arbit.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "arbit.selectorLabels" . | nindent 4 }}

--- a/charts/arbit/templates/serviceaccount.yaml
+++ b/charts/arbit/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "arbit.serviceAccountName" . }}
+  labels:
+    {{- include "arbit.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/charts/arbit/values.yaml
+++ b/charts/arbit/values.yaml
@@ -1,0 +1,165 @@
+# ── Image ─────────────────────────────────────────────────────────────────────
+image:
+  repository: ghcr.io/nfvelten/arbit
+  # Defaults to the chart's appVersion when empty.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# ── Replicas ──────────────────────────────────────────────────────────────────
+replicaCount: 1
+
+# ── Gateway config ────────────────────────────────────────────────────────────
+# Rendered verbatim into a ConfigMap mounted at /app/gateway.yml.
+# Use ${VAR} placeholders for secrets — they are resolved from env vars at startup.
+config:
+  gateway: |
+    transport:
+      type: http
+      addr: "0.0.0.0:4000"
+      upstream: "${ARBIT_UPSTREAM_URL}"
+
+    agents: {}
+
+    rules:
+      block_prompt_injection: true
+      filter_mode: block
+
+    audits:
+      - type: stdout
+
+# ── Environment variables ─────────────────────────────────────────────────────
+# Injected into the arbit container. Use this to supply secrets referenced
+# via ${VAR} in gateway.yml — e.g. from a Kubernetes Secret.
+#
+# Example — reference an existing Secret:
+#   env:
+#     - name: ARBIT_UPSTREAM_URL
+#       valueFrom:
+#         secretKeyRef:
+#           name: arbit-secrets
+#           key: upstream-url
+#     - name: ARBIT_ADMIN_TOKEN
+#       valueFrom:
+#         secretKeyRef:
+#           name: arbit-secrets
+#           key: admin-token
+env: []
+
+# Load all keys from an existing Secret as env vars (envFrom).
+# Useful when all ARBIT_* vars live in a single Secret.
+existingSecret: ""
+
+# ── Service ───────────────────────────────────────────────────────────────────
+service:
+  type: ClusterIP
+  port: 4000
+
+# ── ServiceAccount ────────────────────────────────────────────────────────────
+serviceAccount:
+  create: true
+  # Name of the ServiceAccount to use. Auto-generated from chart fullname when empty.
+  name: ""
+  annotations: {}
+
+# ── Security contexts ─────────────────────────────────────────────────────────
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10001
+  fsGroup: 10001
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+# ── Resources ─────────────────────────────────────────────────────────────────
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+# ── Probes ────────────────────────────────────────────────────────────────────
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 15
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 3
+  periodSeconds: 10
+
+# ── Autoscaling ───────────────────────────────────────────────────────────────
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# ── Pod Disruption Budget ─────────────────────────────────────────────────────
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 1
+
+# ── Network Policy ────────────────────────────────────────────────────────────
+# Restricts ingress to pods with the label `arbit-client: "true"`.
+networkPolicy:
+  enabled: false
+  # Additional ingress rules appended to the generated policy.
+  additionalIngressRules: []
+
+# ── Sidecar pattern ───────────────────────────────────────────────────────────
+# Add extra containers to the Pod (e.g. the AI agent that calls arbit).
+# These containers share the Pod network — the agent reaches arbit at localhost:4000.
+#
+# Example:
+#   extraContainers:
+#     - name: my-agent
+#       image: my-org/my-agent:latest
+#       env:
+#         - name: MCP_GATEWAY_URL
+#           value: http://localhost:4000/mcp
+extraContainers: []
+
+# Extra init containers.
+initContainers: []
+
+# Extra volumes and mounts (e.g. TLS certs, custom CA bundles).
+extraVolumes: []
+extraVolumeMounts: []
+
+# ── Audit persistence ─────────────────────────────────────────────────────────
+# When enabled, mounts a PersistentVolumeClaim for the SQLite audit database.
+persistence:
+  enabled: false
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 1Gi
+  # existingClaim: ""
+
+# ── Pod annotations and labels ────────────────────────────────────────────────
+podAnnotations: {}
+podLabels: {}
+
+# ── Node scheduling ───────────────────────────────────────────────────────────
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# ── Graceful shutdown ─────────────────────────────────────────────────────────
+# Should match terminationGracePeriodSeconds to allow audit flush before SIGKILL.
+terminationGracePeriodSeconds: 30


### PR DESCRIPTION
## Summary

Production-ready Helm chart at `charts/arbit/` for deploying arbit on Kubernetes.

**Resources rendered by default:**
- `ServiceAccount` (automount disabled)
- `ConfigMap` — `gateway.yml` from `values.yaml`; supports `${VAR}` env var placeholders
- `Service` (ClusterIP :4000)
- `Deployment` — non-root uid 10001, readOnly root FS, liveness/readiness probes at `/health`, config checksum annotation, `terminationGracePeriodSeconds: 30`

**Optional (disabled by default):**
- `HorizontalPodAutoscaler` — CPU/memory targets
- `PodDisruptionBudget`
- `NetworkPolicy` — restricts ingress to pods labelled `arbit-client: "true"`
- `PersistentVolumeClaim` — for SQLite audit log persistence

**Sidecar pattern** via `extraContainers` in `values.yaml` — agent container shares the Pod network and reaches arbit at `localhost:4000`.

## Test plan

- [x] `helm lint charts/arbit` — 0 failures
- [x] `helm template` renders all 8 resource kinds correctly
- [x] Optional resources (HPA, PDB, NetworkPolicy, PVC) only render when `enabled: true`
- [x] `existingSecret` renders `envFrom` block in Deployment
- [x] `cargo test --lib` — 335 tests passing

Closes #19