### PR TITLE
fix: update integration test assertion for generic auth error

### DIFF
--- a/tests/http_gateway.rs
+++ b/tests/http_gateway.rs
@@ -167,8 +167,8 @@ async fn unknown_agent_is_blocked() {
         .await;
     let msg = body.to_string().to_lowercase();
     assert!(
-        msg.contains("unknown"),
-        "expected unknown agent error, got: {body}"
+        msg.contains("not authorized"),
+        "expected not authorized error, got: {body}"
     );
 }
 


### PR DESCRIPTION
## Summary

The `unknown_agent_is_blocked` integration test was asserting the old `"unknown"` error string. After #31 merged, `AuthMiddleware` returns `"not authorized"` uniformly — this updates the assertion to match.

## Issues

Follow-up to #31.