### PR TITLE
feat: OAuth 2.1 + PKCE upstream authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **OAuth 2.1 + PKCE for upstream authentication** (`oauth.rs`, `upstream/http.rs`, `transport/http.rs`): arbit can now authenticate itself to upstream MCP servers using the authorization code flow with PKCE (RFC 7636). Configure `oauth:` under a named upstream, visit the printed authorization URL once, and arbit refreshes tokens automatically. The `/oauth/callback` endpoint handles the provider redirect. Closes #3.
+
 ---
 
 ## [0.17.0] — 2026-04-01

--- a/src/bin/arbit.rs
+++ b/src/bin/arbit.rs
@@ -14,6 +14,7 @@ use arbit::{
         payload_filter::PayloadFilterMiddleware, rate_limit::RateLimitMiddleware,
         schema_validation::SchemaValidationMiddleware,
     },
+    oauth::OAuthManager,
     prompt_injection,
     schema_cache::SchemaCache,
     transport::{Transport, http::HttpTransport, stdio::StdioTransport},
@@ -297,12 +298,32 @@ async fn cmd_start(config_path: String) -> anyhow::Result<()> {
         )))
         .add(Arc::new(PayloadFilterMiddleware::new(config_rx.clone())));
 
+    // ── OAuth manager (shared between transport callback + HttpUpstream) ───────
+    let oauth_manager = Arc::new(OAuthManager::new());
+
     // ── Named upstreams ───────────────────────────────────────────────────────
     let named_upstreams: HashMap<String, Arc<dyn McpUpstream>> = config
         .upstreams
         .iter()
-        .map(|(name, url)| {
-            let upstream: Arc<dyn McpUpstream> = Arc::new(HttpUpstream::new(url));
+        .map(|(name, def)| {
+            let upstream: Arc<dyn McpUpstream> = if let Some(oauth_cfg) = def.oauth() {
+                let auth_url = oauth_manager.authorization_url(name, oauth_cfg);
+                tracing::info!(
+                    upstream = %name,
+                    url = %auth_url,
+                    "OAuth authorization required — visit the URL to authorize arbit"
+                );
+                Arc::new(HttpUpstream::with_oauth(
+                    def.url(),
+                    5,
+                    30,
+                    Arc::clone(&oauth_manager),
+                    name.clone(),
+                    oauth_cfg.clone(),
+                ))
+            } else {
+                Arc::new(HttpUpstream::new(def.url()))
+            };
             (name.clone(), upstream)
         })
         .collect();
@@ -346,6 +367,7 @@ async fn cmd_start(config_path: String) -> anyhow::Result<()> {
                 sqlite_db_path,
                 config.admin_token,
                 hitl_store,
+                oauth_manager,
             )
             .serve(gateway)
             .await?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,8 +20,9 @@ pub struct Config {
     #[serde(default)]
     pub rules: Rules,
     /// Named upstream servers — agents can reference these by name via `upstream:` in their policy.
+    /// Accepts either a plain URL string (backward-compatible) or a full `UpstreamDef` object.
     #[serde(default)]
-    pub upstreams: HashMap<String, String>,
+    pub upstreams: HashMap<String, UpstreamDef>,
     /// JWT / OIDC authentication — single provider or list of providers.
     pub auth: Option<AuthConfig>,
     /// Optional Bearer token required to access `/dashboard` and `/metrics`.
@@ -283,6 +284,85 @@ pub(crate) fn tool_matches(pattern: &str, tool: &str) -> bool {
 
     // The remaining string must end with the required suffix.
     rest.ends_with(suffix)
+}
+
+// ── Named upstreams ───────────────────────────────────────────────────────────
+
+/// A named upstream entry — either a plain URL string or a full config object.
+///
+/// ```yaml
+/// # Short form (backward-compatible)
+/// upstreams:
+///   filesystem: "http://localhost:3001/mcp"
+///
+/// # Full form with OAuth 2.1 + PKCE
+/// upstreams:
+///   filesystem:
+///     url: "http://localhost:3001/mcp"
+///     oauth:
+///       client_id: "my-client"
+///       authorization_url: "https://auth.example.com/authorize"
+///       token_url: "https://auth.example.com/token"
+///       scopes: ["mcp:tools"]
+///       redirect_uri: "http://localhost:4000/oauth/callback"
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum UpstreamDef {
+    /// Plain URL — e.g. `"http://localhost:3001/mcp"`
+    Url(String),
+    /// Full upstream definition with optional OAuth config.
+    Full(UpstreamFull),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UpstreamFull {
+    pub url: String,
+    #[serde(default)]
+    pub oauth: Option<OAuthClientConfig>,
+}
+
+/// OAuth 2.1 + PKCE client configuration for an upstream MCP server.
+///
+/// When present, arbit will obtain and manage access tokens for this upstream
+/// automatically. On first start (or after token expiry), the authorization URL
+/// is logged — the operator must visit it once to authorize arbit.
+#[derive(Debug, Clone, Deserialize)]
+pub struct OAuthClientConfig {
+    /// OAuth client ID registered with the authorization server.
+    pub client_id: String,
+    /// Client secret — omit for public clients (PKCE-only flows).
+    #[serde(default)]
+    pub client_secret: Option<String>,
+    /// Authorization endpoint, e.g. `https://auth.example.com/oauth/authorize`
+    pub authorization_url: String,
+    /// Token endpoint, e.g. `https://auth.example.com/oauth/token`
+    pub token_url: String,
+    /// OAuth scopes to request (space-separated in the URL; listed as YAML array).
+    #[serde(default)]
+    pub scopes: Vec<String>,
+    /// Redirect URI registered with the authorization server.
+    /// Must point to this gateway's `/oauth/callback` endpoint,
+    /// e.g. `http://localhost:4000/oauth/callback`.
+    pub redirect_uri: String,
+}
+
+impl UpstreamDef {
+    /// The upstream's base URL.
+    pub fn url(&self) -> &str {
+        match self {
+            UpstreamDef::Url(u) => u,
+            UpstreamDef::Full(f) => &f.url,
+        }
+    }
+
+    /// OAuth config, if present.
+    pub fn oauth(&self) -> Option<&OAuthClientConfig> {
+        match self {
+            UpstreamDef::Url(_) => None,
+            UpstreamDef::Full(f) => f.oauth.as_ref(),
+        }
+    }
 }
 
 // ── JWT / OIDC ────────────────────────────────────────────────────────────────
@@ -660,8 +740,10 @@ mod tests {
     #[test]
     fn known_upstream_reference_passes() {
         let mut cfg = base();
-        cfg.upstreams
-            .insert("mcp".to_string(), "http://localhost:3000/mcp".to_string());
+        cfg.upstreams.insert(
+            "mcp".to_string(),
+            UpstreamDef::Url("http://localhost:3000/mcp".to_string()),
+        );
         let mut policy = make_agent(None, vec![], 60);
         policy.upstream = Some("mcp".to_string());
         cfg.agents.insert("a".to_string(), policy);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod jwt;
 pub mod live_config;
 pub mod metrics;
 pub mod middleware;
+pub mod oauth;
 pub mod openai_bridge;
 pub mod prompt_injection;
 pub mod schema_cache;

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -1,0 +1,363 @@
+/// OAuth 2.1 + PKCE client for authenticating arbit to upstream MCP servers.
+///
+/// # Flow
+///
+/// 1. For each named upstream with an `oauth:` block, arbit calls
+///    [`OAuthManager::authorization_url`] at startup and logs the URL.
+/// 2. The operator visits the URL in a browser, authorizes arbit, and the
+///    provider redirects to `GET /oauth/callback?code=…&state=…`.
+/// 3. The callback handler calls [`OAuthManager::exchange_code`], which
+///    exchanges the authorization code + PKCE verifier for tokens.
+/// 4. [`OAuthManager::get_token`] is called before every upstream request.
+///    If the access token is close to expiry it is refreshed automatically
+///    using the stored refresh token.  If refresh fails the operator must
+///    re-authorize (the URL is logged again at that point).
+use crate::config::OAuthClientConfig;
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
+use reqwest::Client;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::{
+    collections::HashMap,
+    sync::Mutex,
+    time::{Duration, Instant},
+};
+use uuid::Uuid;
+
+// ── PKCE ─────────────────────────────────────────────────────────────────────
+
+/// A PKCE (RFC 7636) code-verifier / code-challenge pair.
+pub struct PkceChallenge {
+    /// The raw verifier — sent in the token request as `code_verifier`.
+    pub verifier: String,
+    /// S256 challenge — sent in the authorization request as `code_challenge`.
+    pub challenge: String,
+}
+
+impl Default for PkceChallenge {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PkceChallenge {
+    /// Generate a fresh PKCE pair using two UUID v4 values as random material
+    /// (32 bytes total, well within the RFC 7636 range of 32–96 bytes).
+    pub fn new() -> Self {
+        let bytes: Vec<u8> = Uuid::new_v4()
+            .as_bytes()
+            .iter()
+            .chain(Uuid::new_v4().as_bytes().iter())
+            .copied()
+            .collect();
+        let verifier = URL_SAFE_NO_PAD.encode(&bytes);
+        let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
+        Self {
+            verifier,
+            challenge,
+        }
+    }
+}
+
+// ── Internal state ────────────────────────────────────────────────────────────
+
+struct PendingAuth {
+    upstream_name: String,
+    verifier: String,
+    config: OAuthClientConfig,
+}
+
+struct TokenSet {
+    access_token: String,
+    refresh_token: Option<String>,
+    /// When the access token expires; refresh is triggered 60 s early.
+    expires_at: Instant,
+}
+
+// ── OAuthManager ─────────────────────────────────────────────────────────────
+
+/// Thread-safe OAuth 2.1 + PKCE token manager.
+///
+/// Shared between the HTTP transport (callback handler) and each `HttpUpstream`
+/// instance that has an OAuth configuration.
+pub struct OAuthManager {
+    /// In-flight authorization requests: `state` → `PendingAuth`.
+    pending: Mutex<HashMap<String, PendingAuth>>,
+    /// Stored token sets: `upstream_name` → `TokenSet`.
+    tokens: Mutex<HashMap<String, TokenSet>>,
+    client: Client,
+}
+
+impl Default for OAuthManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OAuthManager {
+    pub fn new() -> Self {
+        Self {
+            pending: Mutex::new(HashMap::new()),
+            tokens: Mutex::new(HashMap::new()),
+            client: Client::new(),
+        }
+    }
+
+    /// Build an OAuth 2.1 + PKCE authorization URL for the given upstream.
+    ///
+    /// The generated `state` is stored internally and must be presented back
+    /// by the callback via [`exchange_code`].  The URL must be visited by the
+    /// operator in a browser to authorize arbit.
+    pub fn authorization_url(&self, upstream_name: &str, config: &OAuthClientConfig) -> String {
+        let pkce = PkceChallenge::new();
+        let state = Uuid::new_v4().to_string();
+
+        self.pending.lock().unwrap().insert(
+            state.clone(),
+            PendingAuth {
+                upstream_name: upstream_name.to_string(),
+                verifier: pkce.verifier,
+                config: config.clone(),
+            },
+        );
+
+        let enc = |s: &str| utf8_percent_encode(s, NON_ALPHANUMERIC).to_string();
+
+        let mut url = format!(
+            "{}?response_type=code&client_id={}&redirect_uri={}&code_challenge={}&code_challenge_method=S256&state={}",
+            config.authorization_url,
+            enc(&config.client_id),
+            enc(&config.redirect_uri),
+            pkce.challenge,
+            state,
+        );
+        if !config.scopes.is_empty() {
+            url.push_str(&format!("&scope={}", enc(&config.scopes.join(" "))));
+        }
+        url
+    }
+
+    /// Exchange an authorization code + state for tokens.
+    ///
+    /// Called by the `/oauth/callback` HTTP handler.
+    /// Returns the upstream name that was authorized.
+    pub async fn exchange_code(&self, state: &str, code: &str) -> anyhow::Result<String> {
+        let pending = self
+            .pending
+            .lock()
+            .unwrap()
+            .remove(state)
+            .ok_or_else(|| anyhow::anyhow!("unknown or expired OAuth state"))?;
+
+        let verifier = pending.verifier.clone();
+        let redirect_uri = pending.config.redirect_uri.clone();
+        let client_id = pending.config.client_id.clone();
+
+        let resp = self
+            .token_request(
+                &pending.config,
+                &[
+                    ("grant_type", "authorization_code"),
+                    ("code", code),
+                    ("redirect_uri", &redirect_uri),
+                    ("code_verifier", &verifier),
+                    ("client_id", &client_id),
+                ],
+            )
+            .await?;
+
+        let upstream_name = pending.upstream_name.clone();
+        self.store_token(&upstream_name, resp);
+        tracing::info!(upstream = %upstream_name, "OAuth token obtained");
+        Ok(upstream_name)
+    }
+
+    /// Return a valid access token for `upstream_name`.
+    ///
+    /// Refreshes the token automatically if it is within 60 seconds of expiry.
+    /// Returns `None` if the upstream has not been authorized yet or if refresh
+    /// fails (in which case the operator must re-authorize).
+    pub async fn get_token(
+        &self,
+        upstream_name: &str,
+        config: &OAuthClientConfig,
+    ) -> Option<String> {
+        let (access_token, refresh_token, expired) = {
+            let tokens = self.tokens.lock().unwrap();
+            let t = tokens.get(upstream_name)?;
+            let expired = t.expires_at <= Instant::now() + Duration::from_secs(60);
+            (t.access_token.clone(), t.refresh_token.clone(), expired)
+        };
+
+        if !expired {
+            return Some(access_token);
+        }
+
+        if let Some(rt) = refresh_token {
+            let client_id = config.client_id.clone();
+            match self
+                .token_request(
+                    config,
+                    &[
+                        ("grant_type", "refresh_token"),
+                        ("refresh_token", &rt),
+                        ("client_id", &client_id),
+                    ],
+                )
+                .await
+            {
+                Ok(resp) => {
+                    let token = resp.access_token.clone();
+                    self.store_token(upstream_name, resp);
+                    tracing::info!(upstream = %upstream_name, "OAuth token refreshed");
+                    return Some(token);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        upstream = %upstream_name,
+                        error = %e,
+                        "OAuth token refresh failed — re-authorization required"
+                    );
+                }
+            }
+        }
+
+        None
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn store_token(&self, upstream_name: &str, resp: TokenResponse) {
+        let expires_at = Instant::now() + Duration::from_secs(resp.expires_in.unwrap_or(3600));
+        self.tokens.lock().unwrap().insert(
+            upstream_name.to_string(),
+            TokenSet {
+                access_token: resp.access_token,
+                refresh_token: resp.refresh_token,
+                expires_at,
+            },
+        );
+    }
+
+    async fn token_request(
+        &self,
+        config: &OAuthClientConfig,
+        params: &[(&str, &str)],
+    ) -> anyhow::Result<TokenResponse> {
+        let mut req = self.client.post(&config.token_url).form(params);
+        if let Some(secret) = &config.client_secret {
+            req = req.basic_auth(&config.client_id, Some(secret));
+        }
+        let resp = req.send().await?.json::<TokenResponse>().await?;
+        Ok(resp)
+    }
+}
+
+#[derive(Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    refresh_token: Option<String>,
+    expires_in: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> OAuthClientConfig {
+        OAuthClientConfig {
+            client_id: "test-client".to_string(),
+            client_secret: None,
+            authorization_url: "https://auth.example.com/authorize".to_string(),
+            token_url: "https://auth.example.com/token".to_string(),
+            scopes: vec!["mcp:tools".to_string()],
+            redirect_uri: "http://localhost:4000/oauth/callback".to_string(),
+        }
+    }
+
+    #[test]
+    fn pkce_challenge_is_s256_of_verifier() {
+        let pkce = PkceChallenge::new();
+        let expected = URL_SAFE_NO_PAD.encode(Sha256::digest(pkce.verifier.as_bytes()));
+        assert_eq!(pkce.challenge, expected);
+    }
+
+    #[test]
+    fn pkce_verifier_uses_url_safe_chars() {
+        let pkce = PkceChallenge::new();
+        assert!(
+            pkce.verifier
+                .chars()
+                .all(|c| c.is_alphanumeric() || "-_".contains(c)),
+            "verifier must use URL-safe base64 chars only"
+        );
+    }
+
+    #[test]
+    fn pkce_verifier_meets_rfc7636_length() {
+        let pkce = PkceChallenge::new();
+        assert!(
+            (43..=128).contains(&pkce.verifier.len()),
+            "verifier length must be 43-128 chars per RFC 7636, got {}",
+            pkce.verifier.len()
+        );
+    }
+
+    #[test]
+    fn authorization_url_contains_required_params() {
+        let mgr = OAuthManager::new();
+        let config = test_config();
+        let url = mgr.authorization_url("filesystem", &config);
+        assert!(
+            url.contains("response_type=code"),
+            "must have response_type=code"
+        );
+        assert!(url.contains("code_challenge_method=S256"), "must use S256");
+        assert!(url.contains("code_challenge="), "must include challenge");
+        assert!(url.contains("state="), "must include state");
+        assert!(
+            url.starts_with("https://auth.example.com/authorize"),
+            "must use configured authorization_url"
+        );
+    }
+
+    #[test]
+    fn authorization_url_includes_scope() {
+        let mgr = OAuthManager::new();
+        let url = mgr.authorization_url("fs", &test_config());
+        assert!(url.contains("scope="), "must include scope when configured");
+    }
+
+    #[test]
+    fn authorization_url_omits_scope_when_empty() {
+        let mgr = OAuthManager::new();
+        let mut config = test_config();
+        config.scopes.clear();
+        let url = mgr.authorization_url("fs", &config);
+        assert!(!url.contains("scope="), "must not include scope when empty");
+    }
+
+    #[test]
+    fn each_authorization_url_has_unique_state() {
+        let mgr = OAuthManager::new();
+        let config = test_config();
+        let url1 = mgr.authorization_url("fs", &config);
+        let url2 = mgr.authorization_url("fs", &config);
+        let state1 = url1.split("state=").nth(1).unwrap_or("");
+        let state2 = url2.split("state=").nth(1).unwrap_or("");
+        assert_ne!(state1, state2, "each call must produce a unique state");
+    }
+
+    #[tokio::test]
+    async fn exchange_code_with_unknown_state_returns_error() {
+        let mgr = OAuthManager::new();
+        assert!(mgr.exchange_code("unknown-state", "code").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn get_token_returns_none_for_unknown_upstream() {
+        let mgr = OAuthManager::new();
+        assert!(mgr.get_token("unknown", &test_config()).await.is_none());
+    }
+}

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -6,13 +6,14 @@ use crate::{
     jwt::MultiJwtValidator,
     live_config::LiveConfig,
     metrics::GatewayMetrics,
+    oauth::OAuthManager,
     openai_bridge::{mcp_result_to_openai, mcp_tools_to_openai, openai_tool_call_to_mcp},
 };
 use async_trait::async_trait;
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::{
     Json, Router,
-    extract::{ConnectInfo, State},
+    extract::{ConnectInfo, Query, State},
     http::{HeaderMap, HeaderValue, StatusCode},
     response::IntoResponse,
     routing::{delete, get, post},
@@ -101,6 +102,8 @@ pub struct HttpTransport {
     /// Optional Bearer token required to access /dashboard and /metrics.
     admin_token: Option<String>,
     hitl_store: Arc<HitlStore>,
+    /// OAuth manager — handles the `/oauth/callback` endpoint for upstream auth.
+    oauth_manager: Arc<OAuthManager>,
 }
 
 impl HttpTransport {
@@ -115,6 +118,7 @@ impl HttpTransport {
         audit_db: Option<String>,
         admin_token: Option<String>,
         hitl_store: Arc<HitlStore>,
+        oauth_manager: Arc<OAuthManager>,
     ) -> Self {
         Self {
             addr: addr.into(),
@@ -126,6 +130,7 @@ impl HttpTransport {
             audit_db,
             admin_token,
             hitl_store,
+            oauth_manager,
         }
     }
 }
@@ -141,6 +146,7 @@ struct HttpState {
     /// Optional Bearer token required to access /dashboard and /metrics.
     admin_token: Option<String>,
     hitl_store: Arc<HitlStore>,
+    oauth_manager: Arc<OAuthManager>,
 }
 
 const MAX_AGENT_ID_LEN: usize = 128;
@@ -157,6 +163,7 @@ impl Transport for HttpTransport {
             audit_db: self.audit_db.clone(),
             admin_token: self.admin_token.clone(),
             hitl_store: Arc::clone(&self.hitl_store),
+            oauth_manager: Arc::clone(&self.oauth_manager),
         });
 
         let app = Router::new()
@@ -171,6 +178,7 @@ impl Transport for HttpTransport {
             .route("/approvals/{id}/reject", post(handle_reject))
             .route("/openai/v1/tools", get(handle_openai_tools))
             .route("/openai/v1/execute", post(handle_openai_execute))
+            .route("/oauth/callback", get(handle_oauth_callback))
             .with_state(state);
 
         if let Some(tls) = &self.tls {
@@ -880,6 +888,32 @@ async fn handle_openai_execute(
     }
 
     Json(serde_json::json!({ "tool_results": results })).into_response()
+}
+
+// ── OAuth callback ────────────────────────────────────────────────────────────
+
+#[derive(serde::Deserialize)]
+struct OAuthCallbackParams {
+    code: String,
+    state: String,
+}
+
+async fn handle_oauth_callback(
+    Query(params): Query<OAuthCallbackParams>,
+    State(state): State<Arc<HttpState>>,
+) -> impl IntoResponse {
+    match state
+        .oauth_manager
+        .exchange_code(&params.state, &params.code)
+        .await
+    {
+        Ok(upstream_name) => (
+            StatusCode::OK,
+            format!("Upstream '{upstream_name}' authorized. You may close this tab."),
+        )
+            .into_response(),
+        Err(e) => (StatusCode::BAD_REQUEST, format!("OAuth error: {e}")).into_response(),
+    }
 }
 
 async fn resolve_agent(sessions: &SessionStore, headers: &HeaderMap) -> Result<String, StatusCode> {

--- a/src/upstream/http.rs
+++ b/src/upstream/http.rs
@@ -1,4 +1,5 @@
 use super::McpUpstream;
+use crate::{config::OAuthClientConfig, oauth::OAuthManager};
 use async_trait::async_trait;
 use reqwest::{Client, ClientBuilder};
 use serde_json::{Value, json};
@@ -85,6 +86,9 @@ pub struct HttpUpstream {
     url: String,
     client: Client,
     cb: Arc<CircuitBreaker>,
+    /// Optional OAuth token provider — when set, a `Bearer` token is fetched
+    /// and attached to every upstream request.
+    oauth: Option<(Arc<OAuthManager>, String, OAuthClientConfig)>,
 }
 
 impl HttpUpstream {
@@ -106,7 +110,22 @@ impl HttpUpstream {
             url: url.into(),
             client,
             cb: Arc::new(CircuitBreaker::new(threshold, recovery_secs)),
+            oauth: None,
         }
+    }
+
+    /// Attach an OAuth 2.1 + PKCE token provider to this upstream.
+    pub fn with_oauth(
+        url: impl Into<String>,
+        threshold: usize,
+        recovery_secs: u64,
+        oauth_manager: Arc<OAuthManager>,
+        upstream_name: String,
+        oauth_config: OAuthClientConfig,
+    ) -> Self {
+        let mut up = Self::with_circuit_breaker(url, threshold, recovery_secs);
+        up.oauth = Some((oauth_manager, upstream_name, oauth_config));
+        up
     }
 }
 
@@ -121,7 +140,20 @@ impl McpUpstream for HttpUpstream {
             }));
         }
 
-        match self.client.post(&self.url).json(msg).send().await {
+        // Attach OAuth Bearer token if this upstream is configured with OAuth.
+        let mut req = self.client.post(&self.url).json(msg);
+        if let Some((manager, name, config)) = &self.oauth {
+            if let Some(token) = manager.get_token(name, config).await {
+                req = req.bearer_auth(token);
+            } else {
+                tracing::warn!(
+                    upstream = %name,
+                    "OAuth token unavailable — visit the authorization URL to authorize arbit"
+                );
+            }
+        }
+
+        match req.send().await {
             Ok(resp) => {
                 self.cb.on_success().await;
                 if resp.status() == reqwest::StatusCode::ACCEPTED {


### PR DESCRIPTION
## Summary

- Adds `src/oauth.rs`: `OAuthManager` handles PKCE pair generation, authorization URL construction, authorization code exchange, and automatic token refresh
- `UpstreamDef` enum in `config.rs` makes the new `oauth:` block optional while keeping existing plain-URL configs working without changes
- `HttpUpstream::with_oauth()` fetches a Bearer token before each upstream request and logs a re-authorization reminder when no token is available
- `/oauth/callback` route added to the HTTP transport — providers redirect here after the operator approves arbit's access
- At startup, arbit logs the authorization URL for every OAuth-configured upstream so the operator knows where to go

## Configuration example

```yaml
upstreams:
  filesystem:
    url: "http://localhost:3001/mcp"
    oauth:
      client_id: "arbit"
      authorization_url: "https://auth.example.com/authorize"
      token_url: "https://auth.example.com/token"
      redirect_uri: "http://localhost:4000/oauth/callback"
      scopes: ["mcp:tools"]
```

## Test plan

- [ ] `cargo test --lib` — 363 unit tests pass (includes PKCE correctness, URL params, unique state, error cases)
- [ ] `cargo clippy -- -D warnings` — zero warnings
- [ ] `cargo fmt --check` — no formatting violations
- [ ] Manual: start gateway with OAuth upstream config, visit logged URL, confirm `/oauth/callback` exchanges code and subsequent requests carry Bearer token

Closes #3