### PR TITLE
feat: immutable audit log hash chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ### Added
+- **Immutable audit log — hash chain integrity** (`audit/sqlite.rs`): every new entry stores a `prev_hash` and an `entry_hash` (SHA-256 of the previous hash + all fields). Existing databases are migrated transparently; legacy rows are skipped during verification. New `arbit verify-log <db>` subcommand walks the chain and exits non-zero if any row is missing, tampered, or chain-broken. Closes #10.
+
+### Added
 - **OpenBao secret management** (`secrets/`, `config.rs`): native integration with OpenBao (Vault-compatible). Declare a `secrets:` block in `gateway.yml` to fetch secret values at startup and inject them into the config before the gateway starts. Supports `token`, `approle`, and `kubernetes` auth methods. The `SecretsProvider` trait enables mocking in tests. Closes #22.
 - **OAuth 2.1 + PKCE for upstream authentication** (`oauth.rs`, `upstream/http.rs`, `transport/http.rs`): arbit can now authenticate itself to upstream MCP servers using the authorization code flow with PKCE (RFC 7636). Configure `oauth:` under a named upstream, visit the printed authorization URL once, and arbit refreshes tokens automatically. The `/oauth/callback` endpoint handles the provider redirect. Closes #3.
 

--- a/src/audit/sqlite.rs
+++ b/src/audit/sqlite.rs
@@ -2,9 +2,146 @@ use super::{AuditEntry, AuditLog, Outcome};
 use crate::metrics::GatewayMetrics;
 use async_trait::async_trait;
 use rusqlite::{Connection, params};
+use sha2::{Digest, Sha256};
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 use tokio::sync::mpsc;
+
+// ── Hash chain ────────────────────────────────────────────────────────────────
+
+/// The genesis sentinel — `prev_hash` stored in the very first audit row.
+pub const GENESIS_HASH: &str = "0000000000000000000000000000000000000000000000000000000000000000";
+
+/// Compute the SHA-256 hash that covers both the chaining `prev_hash` and
+/// all observable fields of an audit row.  The inputs are separated by `|`
+/// and `NULL` fields are represented as the literal string `"NULL"`.
+///
+/// Changing any field, or breaking the link to the previous row, will
+/// produce a different hash and be detected by [`verify_chain`].
+#[allow(clippy::too_many_arguments)]
+pub fn compute_entry_hash(
+    prev_hash: &str,
+    ts: i64,
+    agent_id: &str,
+    method: &str,
+    tool: Option<&str>,
+    arguments: Option<&str>,
+    outcome: &str,
+    reason: Option<&str>,
+    input_tokens: i64,
+) -> String {
+    let mut h = Sha256::new();
+    h.update(prev_hash.as_bytes());
+    h.update(b"|");
+    h.update(ts.to_string().as_bytes());
+    h.update(b"|");
+    h.update(agent_id.as_bytes());
+    h.update(b"|");
+    h.update(method.as_bytes());
+    h.update(b"|");
+    h.update(tool.unwrap_or("NULL").as_bytes());
+    h.update(b"|");
+    h.update(arguments.unwrap_or("NULL").as_bytes());
+    h.update(b"|");
+    h.update(outcome.as_bytes());
+    h.update(b"|");
+    h.update(reason.unwrap_or("NULL").as_bytes());
+    h.update(b"|");
+    h.update(input_tokens.to_string().as_bytes());
+    hex::encode(h.finalize())
+}
+
+/// Result of verifying an audit log's hash chain.
+pub enum VerifyResult {
+    /// All `n` entries are intact and the chain is unbroken.
+    Ok { entries: usize },
+    /// An entry's stored hash does not match the recomputed value.
+    HashMismatch { row_id: i64 },
+    /// An entry's `prev_hash` does not match the previous entry's `entry_hash`.
+    ChainBroken { row_id: i64 },
+}
+
+/// Walk every row of `audit_log` in insertion order and verify the hash chain.
+///
+/// Returns [`VerifyResult::Ok`] if every entry passes, or the first failing
+/// row otherwise.  Only rows that have non-empty `entry_hash` fields are
+/// verified — legacy rows written before this feature was introduced are
+/// skipped transparently.
+pub fn verify_chain(conn: &Connection) -> anyhow::Result<VerifyResult> {
+    let mut stmt = conn.prepare(
+        "SELECT id, ts, agent_id, method, tool, arguments, outcome, reason, \
+         input_tokens, prev_hash, entry_hash \
+         FROM audit_log ORDER BY id ASC",
+    )?;
+
+    let mut prev_hash = GENESIS_HASH.to_string();
+    let mut entries = 0usize;
+
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, i64>(0)?,            // id
+            row.get::<_, i64>(1)?,            // ts
+            row.get::<_, String>(2)?,         // agent_id
+            row.get::<_, String>(3)?,         // method
+            row.get::<_, Option<String>>(4)?, // tool
+            row.get::<_, Option<String>>(5)?, // arguments
+            row.get::<_, String>(6)?,         // outcome
+            row.get::<_, Option<String>>(7)?, // reason
+            row.get::<_, i64>(8)?,            // input_tokens
+            row.get::<_, String>(9)?,         // prev_hash
+            row.get::<_, String>(10)?,        // entry_hash
+        ))
+    })?;
+
+    for row in rows {
+        let (
+            id,
+            ts,
+            agent_id,
+            method,
+            tool,
+            arguments,
+            outcome,
+            reason,
+            input_tokens,
+            stored_prev,
+            stored_hash,
+        ) = row?;
+
+        // Skip legacy rows that were written before the hash-chain feature.
+        if stored_hash.is_empty() {
+            prev_hash = stored_hash.clone();
+            continue;
+        }
+
+        // Verify chain link
+        if stored_prev != prev_hash {
+            return Ok(VerifyResult::ChainBroken { row_id: id });
+        }
+
+        // Recompute hash
+        let expected = compute_entry_hash(
+            &stored_prev,
+            ts,
+            &agent_id,
+            &method,
+            tool.as_deref(),
+            arguments.as_deref(),
+            &outcome,
+            reason.as_deref(),
+            input_tokens,
+        );
+
+        if expected != stored_hash {
+            return Ok(VerifyResult::HashMismatch { row_id: id });
+        }
+
+        prev_hash = stored_hash;
+        entries += 1;
+    }
+
+    Ok(VerifyResult::Ok { entries })
+}
 
 /// Maximum number of pending audit entries in the channel.
 /// If the SQLite worker falls behind and the channel fills up, entries are
@@ -39,7 +176,9 @@ impl SqliteAudit {
                 arguments    TEXT,
                 outcome      TEXT    NOT NULL,
                 reason       TEXT,
-                input_tokens INTEGER NOT NULL DEFAULT 0
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                prev_hash    TEXT    NOT NULL DEFAULT '',
+                entry_hash   TEXT    NOT NULL DEFAULT ''
             );",
         )?;
         // Migrate existing databases that don't have the arguments column yet.
@@ -48,6 +187,11 @@ impl SqliteAudit {
         let _ = conn.execute_batch(
             "ALTER TABLE audit_log ADD COLUMN input_tokens INTEGER NOT NULL DEFAULT 0;",
         );
+        // Migrate existing databases that don't have the hash-chain columns yet.
+        let _ = conn
+            .execute_batch("ALTER TABLE audit_log ADD COLUMN prev_hash TEXT NOT NULL DEFAULT '';");
+        let _ = conn
+            .execute_batch("ALTER TABLE audit_log ADD COLUMN entry_hash TEXT NOT NULL DEFAULT '';");
         let conn = Arc::new(Mutex::new(conn));
         let (tx, mut rx) = mpsc::channel::<Arc<AuditEntry>>(CHANNEL_CAPACITY);
 
@@ -101,10 +245,33 @@ impl SqliteAudit {
                             .arguments
                             .as_ref()
                             .and_then(|v| serde_json::to_string(v).ok());
+
+                        // Fetch the entry_hash of the most recent row to chain from.
+                        let prev_hash: String = c
+                            .query_row(
+                                "SELECT entry_hash FROM audit_log ORDER BY id DESC LIMIT 1",
+                                [],
+                                |r| r.get(0),
+                            )
+                            .unwrap_or_else(|_| GENESIS_HASH.to_string());
+
+                        let entry_hash = compute_entry_hash(
+                            &prev_hash,
+                            ts,
+                            &entry.agent_id,
+                            &entry.method,
+                            entry.tool.as_deref(),
+                            args_json.as_deref(),
+                            &outcome_str,
+                            reason.as_deref(),
+                            entry.input_tokens as i64,
+                        );
+
                         if let Err(e) = c.execute(
                             "INSERT INTO audit_log \
-                             (ts, agent_id, method, tool, arguments, outcome, reason, input_tokens) \
-                             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                             (ts, agent_id, method, tool, arguments, outcome, reason, \
+                              input_tokens, prev_hash, entry_hash) \
+                             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
                             params![
                                 ts,
                                 entry.agent_id,
@@ -113,7 +280,9 @@ impl SqliteAudit {
                                 args_json,
                                 outcome_str,
                                 reason,
-                                entry.input_tokens as i64
+                                entry.input_tokens as i64,
+                                prev_hash,
+                                entry_hash
                             ],
                         ) {
                             tracing::error!(
@@ -392,5 +561,180 @@ mod tests {
         // rows + drops should equal CHANNEL_CAPACITY + 10
         // (some may have been processed before the channel filled)
         assert!(rows > 0, "at least some entries must have been persisted");
+    }
+
+    // ── Hash chain ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn compute_entry_hash_is_deterministic() {
+        let h1 = compute_entry_hash(
+            GENESIS_HASH,
+            1_000_000,
+            "agent",
+            "tools/call",
+            Some("read_file"),
+            None,
+            "allowed",
+            None,
+            0,
+        );
+        let h2 = compute_entry_hash(
+            GENESIS_HASH,
+            1_000_000,
+            "agent",
+            "tools/call",
+            Some("read_file"),
+            None,
+            "allowed",
+            None,
+            0,
+        );
+        assert_eq!(h1, h2, "same inputs must produce same hash");
+    }
+
+    #[test]
+    fn compute_entry_hash_changes_on_field_mutation() {
+        let base = compute_entry_hash(
+            GENESIS_HASH,
+            1_000_000,
+            "agent",
+            "tools/call",
+            None,
+            None,
+            "allowed",
+            None,
+            0,
+        );
+        let mutated = compute_entry_hash(
+            GENESIS_HASH,
+            1_000_000,
+            "agent",
+            "tools/call",
+            None,
+            None,
+            "blocked",
+            None,
+            0,
+        );
+        assert_ne!(
+            base, mutated,
+            "different outcome must produce different hash"
+        );
+    }
+
+    #[test]
+    fn compute_entry_hash_is_hex_sha256() {
+        let h = compute_entry_hash(GENESIS_HASH, 0, "a", "b", None, None, "c", None, 0);
+        assert_eq!(h.len(), 64, "SHA-256 hex is 64 chars");
+        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[tokio::test]
+    async fn verify_chain_ok_on_intact_log() {
+        let f = NamedTempFile::new().unwrap();
+        let path = f.path().to_str().unwrap();
+        let audit = SqliteAudit::new(path, test_metrics()).unwrap();
+        audit.record(entry(Outcome::Allowed));
+        audit.record(entry(Outcome::Blocked("test".to_string())));
+        audit.record(entry(Outcome::Forwarded));
+        audit.flush().await;
+
+        let conn = Connection::open(path).unwrap();
+        let result = verify_chain(&conn).unwrap();
+        assert!(
+            matches!(result, VerifyResult::Ok { entries: 3 }),
+            "expected Ok with 3 entries"
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_chain_detects_hash_mismatch() {
+        let f = NamedTempFile::new().unwrap();
+        let path = f.path().to_str().unwrap();
+        let audit = SqliteAudit::new(path, test_metrics()).unwrap();
+        audit.record(entry(Outcome::Allowed));
+        audit.flush().await;
+
+        // Tamper: overwrite the entry_hash in the database
+        let conn = Connection::open(path).unwrap();
+        conn.execute(
+            "UPDATE audit_log SET entry_hash = 'deadbeef' WHERE id = 1",
+            [],
+        )
+        .unwrap();
+
+        let result = verify_chain(&conn).unwrap();
+        assert!(
+            matches!(result, VerifyResult::HashMismatch { row_id: 1 }),
+            "expected HashMismatch on row 1"
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_chain_detects_chain_break() {
+        let f = NamedTempFile::new().unwrap();
+        let path = f.path().to_str().unwrap();
+        let audit = SqliteAudit::new(path, test_metrics()).unwrap();
+        audit.record(entry(Outcome::Allowed));
+        audit.record(entry(Outcome::Allowed));
+        audit.flush().await;
+
+        // Break the chain: change row 2's prev_hash without updating entry_hash
+        let conn = Connection::open(path).unwrap();
+        conn.execute(
+            "UPDATE audit_log SET prev_hash = 'badhash' WHERE id = 2",
+            [],
+        )
+        .unwrap();
+
+        let result = verify_chain(&conn).unwrap();
+        assert!(
+            matches!(result, VerifyResult::ChainBroken { row_id: 2 }),
+            "expected ChainBroken on row 2"
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_chain_empty_log_returns_ok() {
+        let f = NamedTempFile::new().unwrap();
+        let path = f.path().to_str().unwrap();
+        SqliteAudit::new(path, test_metrics()).unwrap();
+
+        let conn = Connection::open(path).unwrap();
+        let result = verify_chain(&conn).unwrap();
+        assert!(
+            matches!(result, VerifyResult::Ok { entries: 0 }),
+            "empty log should verify OK"
+        );
+    }
+
+    #[tokio::test]
+    async fn each_entry_links_to_previous_hash() {
+        let f = NamedTempFile::new().unwrap();
+        let path = f.path().to_str().unwrap();
+        let audit = SqliteAudit::new(path, test_metrics()).unwrap();
+        audit.record(entry(Outcome::Allowed));
+        audit.record(entry(Outcome::Allowed));
+        audit.flush().await;
+
+        let conn = Connection::open(path).unwrap();
+        let hashes: Vec<(String, String)> = {
+            let mut stmt = conn
+                .prepare("SELECT prev_hash, entry_hash FROM audit_log ORDER BY id")
+                .unwrap();
+            stmt.query_map([], |r| Ok((r.get(0)?, r.get(1)?)))
+                .unwrap()
+                .map(|r| r.unwrap())
+                .collect()
+        };
+
+        assert_eq!(
+            hashes[0].0, GENESIS_HASH,
+            "first entry prev_hash must be genesis"
+        );
+        assert_eq!(
+            hashes[1].0, hashes[0].1,
+            "second entry prev_hash must equal first entry_hash"
+        );
     }
 }

--- a/src/bin/arbit.rs
+++ b/src/bin/arbit.rs
@@ -1,7 +1,11 @@
 use arbit::{
     audit::{
-        AuditLog, fanout::FanoutAudit, openlineage::OpenLineageAudit, sqlite::SqliteAudit,
-        stdout::StdoutAudit, webhook::WebhookAudit,
+        AuditLog,
+        fanout::FanoutAudit,
+        openlineage::OpenLineageAudit,
+        sqlite::{SqliteAudit, VerifyResult, verify_chain},
+        stdout::StdoutAudit,
+        webhook::WebhookAudit,
     },
     config::{AuditConfig, Config, SecretsConfig, TelemetryConfig, TransportConfig},
     env_config,
@@ -60,6 +64,12 @@ enum Command {
         /// Path to the gateway config file
         #[arg(default_value = "gateway.yml")]
         config: String,
+    },
+    /// Verify the integrity of the SQLite audit log hash chain
+    VerifyLog {
+        /// Path to the SQLite audit database
+        #[arg(default_value = "gateway-audit.db")]
+        db: String,
     },
     /// Query the SQLite audit log
     Audit {
@@ -122,7 +132,15 @@ async fn main() -> anyhow::Result<()> {
         .map(|a| {
             matches!(
                 a.as_str(),
-                "start" | "validate" | "audit" | "replay" | "--help" | "-h" | "--version" | "-V"
+                "start"
+                    | "validate"
+                    | "audit"
+                    | "replay"
+                    | "verify-log"
+                    | "--help"
+                    | "-h"
+                    | "--version"
+                    | "-V"
             )
         })
         .unwrap_or(false);
@@ -137,6 +155,7 @@ async fn main() -> anyhow::Result<()> {
         }) {
             Command::Start { config } => cmd_start(config).await,
             Command::Validate { config } => cmd_validate(config),
+            Command::VerifyLog { db } => cmd_verify_log(db),
             Command::Audit {
                 db,
                 agent,
@@ -499,6 +518,26 @@ fn cmd_validate(config_path: String) -> anyhow::Result<()> {
             eprintln!("error: {e}");
         }
         anyhow::bail!("{} error(s) found in {config_path}", errors.len())
+    }
+}
+
+// ── verify-log ─────────────────────────────────────────────────────────────────
+
+fn cmd_verify_log(db_path: String) -> anyhow::Result<()> {
+    let conn = Connection::open(&db_path)?;
+    match verify_chain(&conn)? {
+        VerifyResult::Ok { entries } => {
+            println!("OK: {entries} entries verified — audit log integrity confirmed");
+            Ok(())
+        }
+        VerifyResult::HashMismatch { row_id } => {
+            anyhow::bail!("TAMPERED: row {row_id} — stored hash does not match recomputed value")
+        }
+        VerifyResult::ChainBroken { row_id } => {
+            anyhow::bail!(
+                "TAMPERED: row {row_id} — prev_hash does not match the previous entry's hash"
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Every new audit entry stores `prev_hash` (the previous row's `entry_hash`) and `entry_hash` (SHA-256 over all observable fields)
- Existing databases are migrated via `ALTER TABLE` — legacy rows with empty `entry_hash` are transparently skipped during verification, so no false positives on old logs
- New `arbit verify-log <db>` subcommand walks the chain in insertion order and exits non-zero with a clear `TAMPERED:` message if any row fails

## How it works

```
entry_hash = SHA-256(
  prev_hash | ts | agent_id | method | tool | arguments |
  outcome | reason | input_tokens
)
```

The first row's `prev_hash` is the genesis sentinel (64 zero hex digits). Any modification to a field, deletion of a row, or insertion between existing rows breaks the chain and is detected.

## CLI usage

```bash
# Verify integrity
arbit verify-log gateway-audit.db
# OK: 1234 entries verified — audit log integrity confirmed

# Tampered log exits 1
arbit verify-log tampered.db
# Error: TAMPERED: row 42 — stored hash does not match recomputed value
```

## Test plan

- [ ] `cargo test --lib` — 380 unit tests pass (8 new hash-chain tests)
- [ ] `cargo clippy -- -D warnings` — zero warnings
- [ ] `cargo fmt --check` — no formatting violations
- [ ] Manual: write entries, run `verify-log` → OK; tamper a row in SQLite, run again → TAMPERED

Closes #10