### PR TITLE
feat: OPA/Rego policy engine middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- **OPA/Rego policy engine** (`middleware/opa.rs`, `config.rs`): embedded Rego policy evaluation via `regorus`. Declare `rules.opa.policy_path` in `gateway.yml` to gate every `tools/call` against a Rego policy. Input exposes `agent_id`, `method`, `tool_name`, `arguments`, and `client_ip`. Defaults to `data.mcp.allow`; any falsy result or evaluation error blocks the request. Hot-reload picks up policy file changes automatically. Closes #8.
 - **Observability Dashboard enhancements** (`transport/http.rs`): rebuilt `/dashboard` with filter bar (agent, outcome, tool, since), summary stats cards (total, allowed, blocked, block rate %), paginated audit table (100 entries/page), and operator **kill switch** — block/unblock individual tools from the UI without restarting the gateway. Blocked tools return a JSON-RPC error immediately, before the middleware pipeline. Closes #4.
 - **Immutable audit log — hash chain integrity** (`audit/sqlite.rs`): every new entry stores a `prev_hash` and an `entry_hash` (SHA-256 of the previous hash + all fields). Existing databases are migrated transparently; legacy rows are skipped during verification. New `arbit verify-log <db>` subcommand walks the chain and exits non-zero if any row is missing, tampered, or chain-broken. Closes #10.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,8 +109,8 @@ dependencies = [
  "clap",
  "futures-util",
  "hex",
- "jsonschema",
- "jsonwebtoken",
+ "jsonschema 0.18.3",
+ "jsonwebtoken 10.3.0",
  "lru",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -118,6 +118,7 @@ dependencies = [
  "percent-encoding",
  "prometheus",
  "regex",
+ "regorus",
  "reqwest",
  "rusqlite",
  "serde",
@@ -357,7 +358,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -365,6 +375,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -380,6 +396,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "bumpalo"
@@ -424,14 +446,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
 ]
 
 [[package]]
@@ -496,6 +541,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const_format"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,6 +577,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -539,7 +619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -558,6 +638,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "der"
@@ -674,6 +760,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "env_home"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,7 +808,18 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
 ]
@@ -745,6 +851,17 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fluent-uri"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
 
 [[package]]
 name = "fnv"
@@ -917,6 +1034,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -1334,7 +1452,25 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
 dependencies = [
- "nom",
+ "nom 8.0.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1384,7 +1520,7 @@ dependencies = [
  "anyhow",
  "base64",
  "bytecount",
- "fancy-regex",
+ "fancy-regex 0.13.0",
  "fraction",
  "getrandom 0.2.17",
  "iso8601",
@@ -1400,6 +1536,45 @@ dependencies = [
  "time",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26a960f0c34d5423581d858ce94815cc11f0171b09939409097969ed269ede1b"
+dependencies = [
+ "ahash",
+ "base64",
+ "bytecount",
+ "email_address",
+ "fancy-regex 0.14.0",
+ "fraction",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "once_cell",
+ "percent-encoding",
+ "referencing",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -1527,6 +1702,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,6 +1724,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,6 +1738,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1747,6 +1948,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,6 +2026,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1876,6 +2101,15 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "pori"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a63d338dec139f56dacc692ca63ad35a6be6a797442479b55acd611d79e906"
+dependencies = [
+ "nom 7.1.3",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1961,7 +2195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2085,6 +2319,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,12 +2368,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "referencing"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb8e15af8558cb157432dd3d88c1d1e982d0a5755cf80ce593b6499260aebc49"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "once_cell",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -2159,6 +2443,38 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "regorus"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843c3d97f07e3b5ac0955d53ad0af4c91fe4a4f8525843ece5bf014f27829b73"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "chrono-tz",
+ "constant_time_eq",
+ "data-encoding",
+ "hex",
+ "hmac",
+ "itertools 0.13.0",
+ "jsonschema 0.26.2",
+ "jsonwebtoken 9.3.1",
+ "lazy_static",
+ "md-5",
+ "rand 0.8.5",
+ "regex",
+ "scientific",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sha1",
+ "sha2",
+ "url",
+ "uuid",
+ "wax",
+]
 
 [[package]]
 name = "reqwest"
@@ -2346,6 +2662,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "scientific"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a4b339a8de779ecb098a772ecbba2ace74e23ed959a5b4f30631d8bf1799a8"
+dependencies = [
+ "scientific-macro",
+]
+
+[[package]]
+name = "scientific-macro"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ee4885492bb655bfa05d039cd9163eb8fe9f79ddebf00ca23a1637510c2fd2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2451,13 +2787,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2507,6 +2854,12 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
@@ -3051,7 +3404,19 @@ checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "rand 0.10.0",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "uuid",
+ "vsimd",
 ]
 
 [[package]]
@@ -3071,6 +3436,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "want"
@@ -3205,6 +3576,20 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
+]
+
+[[package]]
+name = "wax"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d12a78aa0bab22d2f26ed1a96df7ab58e8a93506a3e20adb47c51a93b4e1357"
+dependencies = [
+ "const_format",
+ "itertools 0.11.0",
+ "nom 7.1.3",
+ "pori",
+ "regex",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ sha2 = "0.10"
 hex = "0.4"
 which = "7"
 lru = "0.16.3"
+regorus = "0.2"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/README.md
+++ b/README.md
@@ -307,6 +307,8 @@ agents:
 | `block_prompt_injection` | `true` to enable built-in prompt injection detection (7 patterns). Matched requests are always blocked, even in `redact` mode. Default: `false`. |
 | `ip_rate_limit` | Max `tools/call` requests per minute per client IP. Applied before per-agent limits. Optional. |
 | `validate_schema` | `true` to enable JSON schema validation of `tools/call` arguments against the `inputSchema` from `tools/list`. Requests with invalid or unexpected fields are blocked. Default: `false`. |
+| `opa.policy_path` | Path to a Rego policy file (`.rego`). When set, every `tools/call` is evaluated against the policy before reaching the upstream. Requests that do not satisfy the entrypoint are blocked. Optional. |
+| `opa.entrypoint` | Rego query to evaluate. Must resolve to a boolean. Default: `data.mcp.allow`. |
 
 ```yaml
 rules:
@@ -316,7 +318,31 @@ rules:
   filter_mode: redact          # scrub instead of block
   block_prompt_injection: true # detect "ignore previous instructions" etc.
   ip_rate_limit: 100
+  opa:
+    policy_path: policy.rego   # path to Rego policy file
+    entrypoint: data.mcp.allow # boolean query (default)
 ```
+
+**Example policy** (`policy.rego`):
+
+```rego
+package mcp
+import future.keywords.if
+
+default allow := false
+
+# Only allow read-only tools during business hours
+allow if {
+    input.tool_name == "read_file"
+}
+
+# Trusted agents can call any tool
+allow if {
+    input.agent_id == "ops-agent"
+}
+```
+
+The policy input object contains: `agent_id`, `method`, `tool_name`, `arguments`, `client_ip`. Policy file changes are picked up automatically on hot-reload.
 
 Config changes to `agents` and `rules` are picked up automatically — no restart required.
 

--- a/src/bin/arbit.rs
+++ b/src/bin/arbit.rs
@@ -1,3 +1,4 @@
+use arbit::live_config::OpaPolicy;
 use arbit::{
     audit::{
         AuditLog,
@@ -15,7 +16,7 @@ use arbit::{
     live_config::LiveConfig,
     metrics::GatewayMetrics,
     middleware::{
-        Pipeline, auth::AuthMiddleware, hitl::HitlMiddleware,
+        Pipeline, auth::AuthMiddleware, hitl::HitlMiddleware, opa::OpaMiddleware,
         payload_filter::PayloadFilterMiddleware, rate_limit::RateLimitMiddleware,
         schema_validation::SchemaValidationMiddleware,
     },
@@ -238,14 +239,18 @@ async fn cmd_start(config_path: String) -> anyhow::Result<()> {
         vec![]
     };
 
-    let live = Arc::new(LiveConfig::new(
-        config.agents,
-        block_patterns,
-        injection_patterns,
-        config.rules.ip_rate_limit,
-        config.rules.filter_mode,
-        config.default_policy,
-    ));
+    let opa_policy = load_opa_policy(config.rules.opa.as_ref());
+    let live = Arc::new(
+        LiveConfig::new(
+            config.agents,
+            block_patterns,
+            injection_patterns,
+            config.rules.ip_rate_limit,
+            config.rules.filter_mode,
+            config.default_policy,
+        )
+        .with_opa_policy(opa_policy),
+    );
     let (config_tx, config_rx) = watch::channel(live);
 
     // ── Hot-reload ────────────────────────────────────────────────────────────
@@ -317,7 +322,8 @@ async fn cmd_start(config_path: String) -> anyhow::Result<()> {
         .add(Arc::new(SchemaValidationMiddleware::new(
             schema_cache.clone(),
         )))
-        .add(Arc::new(PayloadFilterMiddleware::new(config_rx.clone())));
+        .add(Arc::new(PayloadFilterMiddleware::new(config_rx.clone())))
+        .add(Arc::new(OpaMiddleware::new(config_rx.clone())));
 
     // ── OAuth manager (shared between transport callback + HttpUpstream) ───────
     let oauth_manager = Arc::new(OAuthManager::new());
@@ -913,6 +919,23 @@ fn build_audit_backend(
     }
 }
 
+fn load_opa_policy(cfg: Option<&arbit::config::OpaConfig>) -> Option<Arc<OpaPolicy>> {
+    let cfg = cfg?;
+    match std::fs::read_to_string(&cfg.policy_path) {
+        Ok(content) => {
+            tracing::info!(path = %cfg.policy_path, entrypoint = %cfg.entrypoint, "OPA policy loaded");
+            Some(Arc::new(OpaPolicy {
+                entrypoint: cfg.entrypoint.clone(),
+                content,
+            }))
+        }
+        Err(e) => {
+            tracing::warn!(path = %cfg.policy_path, error = %e, "failed to load OPA policy — OPA disabled");
+            None
+        }
+    }
+}
+
 fn do_reload(
     reload_path: &str,
     tx: &tokio::sync::watch::Sender<Arc<LiveConfig>>,
@@ -942,14 +965,18 @@ fn do_reload(
             } else {
                 vec![]
             };
-            let new_live = Arc::new(LiveConfig::new(
-                new_cfg.agents,
-                new_patterns,
-                new_injection,
-                new_cfg.rules.ip_rate_limit,
-                new_cfg.rules.filter_mode,
-                new_cfg.default_policy,
-            ));
+            let new_opa = load_opa_policy(new_cfg.rules.opa.as_ref());
+            let new_live = Arc::new(
+                LiveConfig::new(
+                    new_cfg.agents,
+                    new_patterns,
+                    new_injection,
+                    new_cfg.rules.ip_rate_limit,
+                    new_cfg.rules.filter_mode,
+                    new_cfg.default_policy,
+                )
+                .with_opa_policy(new_opa),
+            );
             if tx.send(new_live).is_ok() {
                 tracing::info!(path = reload_path, "config reloaded");
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -538,6 +538,28 @@ pub struct Rules {
     /// `redact`: scrub matching values and allow the sanitised request.
     #[serde(default)]
     pub filter_mode: FilterMode,
+    /// Optional OPA policy for fine-grained, contextual access control.
+    /// When set, every `tools/call` is evaluated against the Rego policy before
+    /// reaching the upstream. Requests that do not satisfy the entrypoint are blocked.
+    #[serde(default)]
+    pub opa: Option<OpaConfig>,
+}
+
+// ── OPA ───────────────────────────────────────────────────────────────────────
+
+/// Configuration for the embedded OPA/Rego policy engine.
+#[derive(Debug, Deserialize, Clone)]
+pub struct OpaConfig {
+    /// Path to the Rego policy file (`.rego`).
+    pub policy_path: String,
+    /// Rego query to evaluate. Must resolve to a boolean.
+    /// Default: `"data.mcp.allow"`.
+    #[serde(default = "default_opa_entrypoint")]
+    pub entrypoint: String,
+}
+
+fn default_opa_entrypoint() -> String {
+    "data.mcp.allow".to_string()
 }
 
 // ── Secrets ───────────────────────────────────────────────────────────────────

--- a/src/live_config.rs
+++ b/src/live_config.rs
@@ -2,6 +2,12 @@ use crate::config::{AgentPolicy, FilterMode};
 use regex::Regex;
 use std::{collections::HashMap, sync::Arc};
 
+/// Loaded OPA policy — policy file content and the Rego query to evaluate.
+pub struct OpaPolicy {
+    pub entrypoint: String,
+    pub content: String,
+}
+
 /// Hot-reloadable configuration snapshot.
 /// Wrapped in `Arc` and broadcast via `tokio::sync::watch`.
 /// All consumers (`borrow()`) always see the latest reloaded version.
@@ -21,6 +27,8 @@ pub struct LiveConfig {
     pub filter_mode: FilterMode,
     /// Fallback policy for agents not listed in `agents`. None = block unknown agents.
     pub default_policy: Option<AgentPolicy>,
+    /// Pre-loaded OPA policy for contextual access control. None = OPA disabled.
+    pub opa_policy: Option<Arc<OpaPolicy>>,
 }
 
 #[cfg(test)]
@@ -193,6 +201,13 @@ impl LiveConfig {
             ip_rate_limit,
             filter_mode,
             default_policy,
+            opa_policy: None,
         }
+    }
+
+    /// Builder method to attach an OPA policy after construction.
+    pub fn with_opa_policy(mut self, policy: Option<Arc<OpaPolicy>>) -> Self {
+        self.opa_policy = policy;
+        self
     }
 }

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod hitl;
+pub mod opa;
 pub mod payload_filter;
 pub mod rate_limit;
 pub mod schema_validation;

--- a/src/middleware/opa.rs
+++ b/src/middleware/opa.rs
@@ -1,0 +1,260 @@
+use super::{Decision, McpContext, Middleware};
+use crate::live_config::LiveConfig;
+use async_trait::async_trait;
+use std::sync::Arc;
+use tokio::sync::watch;
+
+/// Middleware that evaluates every `tools/call` against an embedded Rego policy.
+///
+/// When `rules.opa` is configured in `gateway.yml`, the policy file is loaded at
+/// startup and on every hot-reload. Each request receives a JSON input object:
+///
+/// ```json
+/// {
+///   "agent_id": "cursor",
+///   "method": "tools/call",
+///   "tool_name": "read_file",
+///   "arguments": { ... },
+///   "client_ip": "1.2.3.4"
+/// }
+/// ```
+///
+/// The middleware evaluates the configured entrypoint (default: `data.mcp.allow`).
+/// A `true` result allows the request; `false` or an evaluation error blocks it.
+pub struct OpaMiddleware {
+    config: watch::Receiver<Arc<LiveConfig>>,
+}
+
+impl OpaMiddleware {
+    pub fn new(config: watch::Receiver<Arc<LiveConfig>>) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait]
+impl Middleware for OpaMiddleware {
+    fn name(&self) -> &'static str {
+        "opa"
+    }
+
+    async fn check(&self, ctx: &McpContext) -> Decision {
+        if ctx.method != "tools/call" {
+            return Decision::Allow { rl: None };
+        }
+
+        let policy = {
+            let cfg = self.config.borrow();
+            cfg.opa_policy.clone()
+        };
+
+        let Some(policy) = policy else {
+            return Decision::Allow { rl: None };
+        };
+
+        let input = serde_json::json!({
+            "agent_id": ctx.agent_id,
+            "method": ctx.method,
+            "tool_name": ctx.tool_name,
+            "arguments": ctx.arguments,
+            "client_ip": ctx.client_ip,
+        });
+
+        match evaluate_policy(&policy.content, &policy.entrypoint, &input) {
+            Ok(true) => Decision::Allow { rl: None },
+            Ok(false) => Decision::Block {
+                reason: "denied by policy".to_string(),
+                rl: None,
+            },
+            Err(e) => {
+                tracing::warn!(
+                    agent = %ctx.agent_id,
+                    tool = ?ctx.tool_name,
+                    error = %e,
+                    "OPA policy evaluation failed — denying by default"
+                );
+                Decision::Block {
+                    reason: "policy evaluation error".to_string(),
+                    rl: None,
+                }
+            }
+        }
+    }
+}
+
+fn evaluate_policy(
+    content: &str,
+    entrypoint: &str,
+    input: &serde_json::Value,
+) -> anyhow::Result<bool> {
+    let input_json = serde_json::to_string(input)?;
+    let input_val = regorus::Value::from_json_str(&input_json)?;
+
+    let mut engine = regorus::Engine::new();
+    engine.add_policy("policy.rego".to_string(), content.to_string())?;
+    engine.set_input(input_val);
+
+    engine.eval_bool_query(entrypoint.to_string(), false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        config::FilterMode,
+        live_config::{LiveConfig, OpaPolicy},
+    };
+    use std::collections::HashMap;
+
+    const ALLOW_ALL_POLICY: &str = r#"
+package mcp
+default allow := true
+"#;
+
+    const DENY_ALL_POLICY: &str = r#"
+package mcp
+default allow := false
+"#;
+
+    const ALLOW_TRUSTED_POLICY: &str = r#"
+package mcp
+import future.keywords.if
+default allow := false
+allow if input.agent_id == "trusted"
+"#;
+
+    const ALLOW_BY_TOOL_POLICY: &str = r#"
+package mcp
+import future.keywords.if
+default allow := false
+allow if input.tool_name == "safe_tool"
+"#;
+
+    fn make_mw(policy_content: Option<&str>) -> OpaMiddleware {
+        let opa = policy_content.map(|content| {
+            Arc::new(OpaPolicy {
+                entrypoint: "data.mcp.allow".to_string(),
+                content: content.to_string(),
+            })
+        });
+        let live = Arc::new(
+            LiveConfig::new(
+                HashMap::new(),
+                vec![],
+                vec![],
+                None,
+                FilterMode::Block,
+                None,
+            )
+            .with_opa_policy(opa),
+        );
+        let (_, rx) = watch::channel(live);
+        OpaMiddleware::new(rx)
+    }
+
+    fn ctx(agent: &str, tool: &str) -> McpContext {
+        McpContext {
+            agent_id: agent.to_string(),
+            method: "tools/call".to_string(),
+            tool_name: Some(tool.to_string()),
+            arguments: None,
+            client_ip: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn no_policy_configured_allows_all() {
+        let mw = make_mw(None);
+        assert!(matches!(
+            mw.check(&ctx("any", "any_tool")).await,
+            Decision::Allow { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn non_tools_call_bypasses_opa() {
+        let mw = make_mw(Some(DENY_ALL_POLICY));
+        let ctx = McpContext {
+            agent_id: "agent".to_string(),
+            method: "initialize".to_string(),
+            tool_name: None,
+            arguments: None,
+            client_ip: None,
+        };
+        assert!(matches!(mw.check(&ctx).await, Decision::Allow { .. }));
+    }
+
+    #[tokio::test]
+    async fn allow_all_policy_allows() {
+        let mw = make_mw(Some(ALLOW_ALL_POLICY));
+        assert!(matches!(
+            mw.check(&ctx("any", "any_tool")).await,
+            Decision::Allow { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn deny_all_policy_blocks() {
+        let mw = make_mw(Some(DENY_ALL_POLICY));
+        assert!(matches!(
+            mw.check(&ctx("any", "any_tool")).await,
+            Decision::Block { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn policy_allows_trusted_agent() {
+        let mw = make_mw(Some(ALLOW_TRUSTED_POLICY));
+        assert!(matches!(
+            mw.check(&ctx("trusted", "any_tool")).await,
+            Decision::Allow { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn policy_blocks_untrusted_agent() {
+        let mw = make_mw(Some(ALLOW_TRUSTED_POLICY));
+        assert!(matches!(
+            mw.check(&ctx("untrusted", "any_tool")).await,
+            Decision::Block { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn policy_gates_by_tool_name() {
+        let mw = make_mw(Some(ALLOW_BY_TOOL_POLICY));
+        assert!(matches!(
+            mw.check(&ctx("agent", "safe_tool")).await,
+            Decision::Allow { .. }
+        ));
+        assert!(matches!(
+            mw.check(&ctx("agent", "dangerous_tool")).await,
+            Decision::Block { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn invalid_policy_blocks_with_error_reason() {
+        let mw = make_mw(Some("this is not valid rego !!!"));
+        if let Decision::Block { reason, .. } = mw.check(&ctx("agent", "tool")).await {
+            assert!(
+                reason.contains("policy") || reason.contains("error"),
+                "unexpected block reason: {reason}"
+            );
+        } else {
+            panic!("expected Block for invalid policy");
+        }
+    }
+
+    #[tokio::test]
+    async fn block_reason_does_not_leak_policy_details() {
+        let mw = make_mw(Some(DENY_ALL_POLICY));
+        if let Decision::Block { reason, .. } = mw.check(&ctx("agent", "tool")).await {
+            assert!(
+                !reason.contains("mcp") && !reason.contains("package"),
+                "reason leaked policy internals: {reason}"
+            );
+        } else {
+            panic!("expected Block");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds embedded Rego policy evaluation via `regorus` as a new middleware stage
- Every `tools/call` is evaluated against the configured policy before reaching the upstream
- Policy input exposes `agent_id`, `method`, `tool_name`, `arguments`, and `client_ip`
- Defaults to `data.mcp.allow`; falsy result or evaluation error blocks the request
- Hot-reload picks up `.rego` file changes automatically (via `SIGUSR1` or 30s interval)
- Entirely optional — no `opa:` block in config means zero overhead

## Configuration

```yaml
rules:
  opa:
    policy_path: policy.rego        # path to Rego file
    entrypoint: data.mcp.allow      # boolean query (default)
```

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test --lib` — 389 tests pass (9 new OPA-specific tests)
- [x] No-config path tested: middleware is transparent when `opa:` is absent
- [x] Error path tested: invalid Rego blocks with generic reason (no internals leaked)

Closes #8