### PR TITLE
test: unit, integration, and e2e tests for Streamable HTTP transport

### DIFF
--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -2171,4 +2171,54 @@ mod tests {
         assert_eq!(store.resolve(&sid1).await, None);
         assert_eq!(store.resolve(&sid2).await, Some("b".to_string()));
     }
+
+    // ── accepts_event_stream ──────────────────────────────────────────────────
+
+    fn headers_with_accept(value: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(
+            axum::http::header::ACCEPT,
+            HeaderValue::from_str(value).unwrap(),
+        );
+        h
+    }
+
+    #[test]
+    fn accepts_event_stream_exact_type() {
+        assert!(accepts_event_stream(&headers_with_accept(
+            "text/event-stream"
+        )));
+    }
+
+    #[test]
+    fn accepts_event_stream_multiple_types_includes_sse() {
+        assert!(accepts_event_stream(&headers_with_accept(
+            "application/json, text/event-stream"
+        )));
+    }
+
+    #[test]
+    fn accepts_event_stream_sse_with_quality_factor() {
+        // q-values are common; we check prefix only (text/event-stream starts the token)
+        assert!(accepts_event_stream(&headers_with_accept(
+            "text/event-stream;q=0.9, application/json"
+        )));
+    }
+
+    #[test]
+    fn accepts_event_stream_false_for_json_only() {
+        assert!(!accepts_event_stream(&headers_with_accept(
+            "application/json"
+        )));
+    }
+
+    #[test]
+    fn accepts_event_stream_false_when_no_accept_header() {
+        assert!(!accepts_event_stream(&HeaderMap::new()));
+    }
+
+    #[test]
+    fn accepts_event_stream_false_for_wildcard_only() {
+        assert!(!accepts_event_stream(&headers_with_accept("*/*")));
+    }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -212,6 +212,19 @@ impl Harness {
         req.send().await.unwrap()
     }
 
+    /// POST /mcp with a custom `Accept` header and optional session.
+    pub async fn post_accept(&self, session: Option<&str>, accept: &str, body: Value) -> Response {
+        let mut req = self
+            .client
+            .post(self.url("/mcp"))
+            .header("accept", accept)
+            .json(&body);
+        if let Some(s) = session {
+            req = req.header("mcp-session-id", s);
+        }
+        req.send().await.unwrap()
+    }
+
     /// POST and deserialize the JSON body.
     pub async fn json(&self, session: Option<&str>, body: Value) -> Value {
         self.post(session, body).await.json().await.unwrap()
@@ -278,22 +291,27 @@ pub fn notif_body() -> Value {
 /// `config_snippet` provides the `agents:`, `rules:`, and `auth:` sections;
 /// the transport and audit sections are generated automatically.
 pub async fn harness(config_snippet: &str) -> Harness {
-    harness_inner(config_snippet, "type: stdout").await
+    harness_inner(config_snippet, "http", "type: stdout").await
 }
 
 /// Like `harness` but uses SQLite audit writing to `audit_db_path`.
 pub async fn harness_with_db_audit(config_snippet: &str, audit_db_path: &str) -> Harness {
     let audit = format!("type: sqlite\n  path: \"{audit_db_path}\"");
-    harness_inner(config_snippet, &audit).await
+    harness_inner(config_snippet, "http", &audit).await
 }
 
-async fn harness_inner(config_snippet: &str, audit_config: &str) -> Harness {
+/// Like `harness` but uses the Streamable HTTP transport (MCP spec 2025-03-26).
+pub async fn harness_streamable(config_snippet: &str) -> Harness {
+    harness_inner(config_snippet, "streamable_http", "type: stdout").await
+}
+
+async fn harness_inner(config_snippet: &str, transport_type: &str, audit_config: &str) -> Harness {
     let (dummy_port, dummy_abort) = start_dummy().await;
     let gw_port = free_port().await;
 
     let config = format!(
         r#"transport:
-  type: http
+  type: {transport_type}
   addr: "0.0.0.0:{gw_port}"
   upstream: "http://127.0.0.1:{dummy_port}/mcp"
   session_ttl_secs: 3600

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -136,9 +136,9 @@ chmod +x tests/mock-server.sh
 # 2. Cleanup
 cleanup() {
     echo -e "\n${YELLOW}🧹 Cleaning up processes and temp files...${NC}"
-    kill $DUMMY_PID $ARBITUS_PID $NODE_PID 2>/dev/null || true
-    fuser -k 3000/tcp 4001/tcp 5000/tcp 2>/dev/null || true
-    rm -rf concurrent_results/ tests/mock-server.sh output-stdio.jsonl tests/fixtures/gateway-hotreload.yml tests/fixtures/gateway-e2e-ip.yml *.log hitl_resp.txt webhook.log tests/node_helper.js tests/policy.rego tests/fixtures/gateway-verify.yml
+    kill $DUMMY_PID $ARBITUS_PID $NODE_PID $STREAMABLE_PID 2>/dev/null || true
+    fuser -k 3000/tcp 4001/tcp 4002/tcp 5000/tcp 2>/dev/null || true
+    rm -rf concurrent_results/ tests/mock-server.sh output-stdio.jsonl tests/fixtures/gateway-hotreload.yml tests/fixtures/gateway-e2e-ip.yml tests/fixtures/gateway-e2e-streamable.yml *.log hitl_resp.txt webhook.log tests/node_helper.js tests/policy.rego tests/fixtures/gateway-verify.yml
 }
 trap cleanup EXIT
 
@@ -378,10 +378,96 @@ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"nam
 if ! grep -q "ok" output-stdio.jsonl; then pass "tampered binary blocked correctly"
 else fail "binary verification — tampered binary was NOT blocked"; fi
 
+echo -e "\n${CYAN}🔀 20. STREAMABLE HTTP TRANSPORT (MCP 2025-03-26)${NC}"
+echo "   Starting gateway with streamable_http transport on port 4002..."
+
+cat << 'EOF' > tests/fixtures/gateway-e2e-streamable.yml
+transport:
+  type: streamable_http
+  addr: "127.0.0.1:4002"
+  upstream: "http://127.0.0.1:3000/mcp"
+agents:
+  cursor:
+    allowed_tools: ["echo"]
+    rate_limit: 100
+  claude-code:
+    denied_tools: ["delete_database"]
+    rate_limit: 100
+EOF
+
+./target/debug/arbitus tests/fixtures/gateway-e2e-streamable.yml >> arbitus.log 2>&1 &
+STREAMABLE_PID=$!
+sleep 2
+
+# initialize → must return application/json even when Accept: text/event-stream is sent
+echo "   Testing initialize always returns application/json..."
+INIT_RESP=$(curl -s -i -X POST http://127.0.0.1:4002/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"cursor","version":"1.0"}}}')
+SESSION_ID=$(echo "$INIT_RESP" | grep -i "mcp-session-id:" | awk '{print $2}' | tr -d '\r')
+CT=$(echo "$INIT_RESP" | grep -i "content-type:" | head -1)
+if echo "$CT" | grep -q "application/json"; then pass "initialize returns application/json (not SSE)"
+else fail "initialize content-type wrong: $CT"; fi
+if [[ -n "$SESSION_ID" ]]; then pass "initialize assigns Mcp-Session-Id: $SESSION_ID"
+else fail "initialize — no mcp-session-id header in response"; fi
+
+# tools/list without SSE Accept → JSON
+echo "   Testing tools/list returns JSON when Accept is not text/event-stream..."
+LIST_JSON=$(curl -s -i -X POST http://127.0.0.1:4002/mcp \
+  -H "Content-Type: application/json" \
+  -H "mcp-session-id: $SESSION_ID" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}')
+CT=$(echo "$LIST_JSON" | grep -i "content-type:" | head -1)
+if echo "$CT" | grep -q "application/json"; then pass "tools/list returns JSON by default"
+else fail "tools/list JSON mode — content-type wrong: $CT"; fi
+
+# tools/list with Accept: text/event-stream → SSE
+echo "   Testing tools/list returns SSE when Accept: text/event-stream..."
+LIST_SSE=$(curl -s -i --max-time 5 -X POST http://127.0.0.1:4002/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -H "mcp-session-id: $SESSION_ID" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/list"}')
+CT=$(echo "$LIST_SSE" | grep -i "content-type:" | head -1)
+if echo "$CT" | grep -q "text/event-stream"; then pass "tools/list returns text/event-stream"
+else fail "tools/list SSE mode — content-type wrong: $CT"; fi
+if echo "$LIST_SSE" | grep -q "event: message"; then pass "SSE body contains 'event: message'"
+else fail "SSE body missing 'event: message'"; fi
+if echo "$LIST_SSE" | grep -q '"tools"'; then pass "SSE data payload contains tools list"
+else fail "SSE data missing tools array"; fi
+
+# tools/call via SSE → response wrapped as SSE message event
+echo "   Testing tools/call response is wrapped as SSE message event..."
+CALL_SSE=$(curl -s -i --max-time 5 -X POST http://127.0.0.1:4002/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -H "mcp-session-id: $SESSION_ID" \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"echo","arguments":{"text":"streamable-e2e"}}}')
+if echo "$CALL_SSE" | grep -q "echo: streamable-e2e"; then pass "tools/call SSE response contains echo result"
+else fail "tools/call SSE — echo result missing"; fi
+
+# DELETE /mcp → 204
+echo "   Testing DELETE /mcp terminates session..."
+DEL_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE http://127.0.0.1:4002/mcp \
+  -H "mcp-session-id: $SESSION_ID")
+if [[ "$DEL_STATUS" == "204" ]]; then pass "DELETE /mcp returns 204 No Content"
+else fail "DELETE /mcp returned $DEL_STATUS (expected 204)"; fi
+
+# Subsequent request with invalidated session → 404
+AFTER_DEL=$(curl -s -o /dev/null -w "%{http_code}" -X POST http://127.0.0.1:4002/mcp \
+  -H "Content-Type: application/json" \
+  -H "mcp-session-id: $SESSION_ID" \
+  -d '{"jsonrpc":"2.0","id":5,"method":"tools/list"}')
+if [[ "$AFTER_DEL" == "404" ]]; then pass "invalidated session returns 404"
+else fail "invalidated session returned $AFTER_DEL (expected 404)"; fi
+
+kill $STREAMABLE_PID 2>/dev/null || true
+
 # ── Final summary ──────────────────────────────────────────────────────────────
 echo ""
 if [[ $FAILURES -eq 0 ]]; then
-    echo -e "${MAGENTA}🏆 ALL 19 SECTIONS PASSED${NC}"
+    echo -e "${MAGENTA}🏆 ALL 20 SECTIONS PASSED${NC}"
 else
     echo -e "${RED}✗ $FAILURES ASSERTION(S) FAILED${NC}"
     exit 1

--- a/tests/streamable_http.rs
+++ b/tests/streamable_http.rs
@@ -1,0 +1,210 @@
+mod common;
+
+use common::*;
+use serde_json::{Value, json};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Parse the first SSE `message` event from a raw SSE body and return its data
+/// parsed as JSON. Panics if no `data:` line is found.
+fn parse_sse_json(body: &str) -> Value {
+    let data = body
+        .lines()
+        .find(|l| l.starts_with("data:"))
+        .unwrap_or_else(|| panic!("no 'data:' line in SSE body:\n{body}"));
+    let json_str = data.trim_start_matches("data:").trim();
+    serde_json::from_str(json_str)
+        .unwrap_or_else(|e| panic!("SSE data is not valid JSON: {e}\ndata: {json_str}"))
+}
+
+// ── Session lifecycle ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn streamable_initialize_returns_json_and_session_id() {
+    let h = harness_streamable(DEFAULT_CONFIG).await;
+    let (sid, body) = h.init("cursor").await;
+    assert!(
+        body["result"]["serverInfo"].is_object(),
+        "serverInfo missing"
+    );
+    assert!(!sid.is_empty(), "session ID must be assigned");
+}
+
+#[tokio::test]
+async fn streamable_initialize_always_returns_json_even_with_sse_accept() {
+    let h = harness_streamable(DEFAULT_CONFIG).await;
+    // Spec: initialize MUST return application/json
+    let resp = h
+        .post_accept(None, "text/event-stream", init_body("cursor"))
+        .await;
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(
+        ct.contains("application/json"),
+        "initialize must return JSON regardless of Accept; got: {ct}"
+    );
+}
+
+#[tokio::test]
+async fn streamable_unknown_session_returns_404() {
+    let h = harness_streamable(DEFAULT_CONFIG).await;
+    let status = h.status(Some("no-such-session"), list_body()).await;
+    assert_eq!(status, 404);
+}
+
+#[tokio::test]
+async fn streamable_delete_session_invalidates_it() {
+    let h = harness_streamable(DEFAULT_CONFIG).await;
+    let (sid, _) = h.init("cursor").await;
+
+    let del = h
+        .client
+        .delete(h.url("/mcp"))
+        .header("mcp-session-id", &sid)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(del.status().as_u16(), 204);
+
+    // Further requests must return 404
+    let status = h.status(Some(&sid), list_body()).await;
+    assert_eq!(status, 404);
+}
+
+// ── JSON vs SSE response mode ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn streamable_tools_list_returns_json_by_default() {
+    let h = harness_streamable(DEFAULT_CONFIG).await;
+    let (sid, _) = h.init("cursor").await;
+    let resp = h.post(Some(&sid), list_body()).await;
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(ct.contains("application/json"), "expected JSON; got: {ct}");
+    let body: Value = resp.json().await.unwrap();
+    assert!(body["result"]["tools"].is_array());
+}
+
+#[tokio::test]
+async fn streamable_tools_list_returns_sse_when_accept_event_stream() {
+    let h = harness_streamable(DEFAULT_CONFIG).await;
+    let (sid, _) = h.init("cursor").await;
+
+    let resp = h
+        .post_accept(Some(&sid), "text/event-stream", list_body())
+        .await;
+
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(
+        ct.contains("text/event-stream"),
+        "expected SSE content-type; got: {ct}"
+    );
+
+    let raw = resp.text().await.unwrap();
+    assert!(
+        raw.contains("event: message"),
+        "SSE body missing event type"
+    );
+
+    let body = parse_sse_json(&raw);
+    assert!(
+        body["result"]["tools"].is_array(),
+        "tools array missing in SSE payload"
+    );
+}
+
+#[tokio::test]
+async fn streamable_tool_call_returns_sse_when_accept_event_stream() {
+    let h = harness_streamable(DEFAULT_CONFIG).await;
+    let (sid, _) = h.init("cursor").await;
+
+    let resp = h
+        .post_accept(
+            Some(&sid),
+            "text/event-stream",
+            call_body("echo", json!({"text": "hello"})),
+        )
+        .await;
+
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(ct.contains("text/event-stream"), "expected SSE; got: {ct}");
+
+    let raw = resp.text().await.unwrap();
+    let body = parse_sse_json(&raw);
+    let text = body["result"]["content"][0]["text"].as_str().unwrap_or("");
+    assert_eq!(text, "echo: hello");
+}
+
+#[tokio::test]
+async fn streamable_blocked_tool_sse_error_has_correct_structure() {
+    let h = harness_streamable(DEFAULT_CONFIG).await;
+    // claude-code has delete_database in its denylist
+    let (sid, _) = h.init("claude-code").await;
+
+    let resp = h
+        .post_accept(
+            Some(&sid),
+            "text/event-stream",
+            call_body("delete_database", json!({})),
+        )
+        .await;
+
+    // Blocked calls return a JSON-RPC error — still wrapped as SSE
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(ct.contains("text/event-stream"), "expected SSE; got: {ct}");
+
+    let raw = resp.text().await.unwrap();
+    let body = parse_sse_json(&raw);
+    assert!(
+        body["error"].is_object(),
+        "expected JSON-RPC error in SSE payload; got: {body}"
+    );
+}
+
+// ── Auth passthrough ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn streamable_api_key_auth_works() {
+    let h = harness_streamable(DEFAULT_CONFIG).await;
+    // secured-agent requires X-Api-Key: test-key-123
+    let resp = h
+        .client
+        .post(h.url("/mcp"))
+        .header("x-api-key", "test-key-123")
+        .json(&init_body("secured-agent"))
+        .send()
+        .await
+        .unwrap();
+    let sid = resp
+        .headers()
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    assert!(!sid.is_empty(), "should get a session with valid api_key");
+}
+
+#[tokio::test]
+async fn streamable_missing_api_key_returns_401() {
+    let h = harness_streamable(DEFAULT_CONFIG).await;
+    let resp = h.post(None, init_body("secured-agent")).await;
+    assert_eq!(resp.status().as_u16(), 401);
+}


### PR DESCRIPTION
## Summary

- 6 unit tests for `accepts_event_stream` in `src/transport/http.rs`
- `harness_streamable()` and `post_accept()` test helpers in `tests/common/mod.rs`
- New `tests/streamable_http.rs` with 10 integration tests: session lifecycle, JSON/SSE response mode selection, blocked-tool SSE error shape, api_key auth
- `tests/e2e.sh` section 20: curl-based smoke tests against a real binary covering all Streamable HTTP behaviors

## Test plan

- [ ] `cargo test --lib` — 413 unit tests pass
- [ ] `cargo test --test streamable_http` — 10 integration tests pass
- [ ] `bash tests/e2e.sh` — section 20 passes (requires built binary + dummy-server)

Closes #112 (tests)